### PR TITLE
Merge shift/scale tensors for conv2D kernels

### DIFF
--- a/xcore/operator_book/lib_nn_operator/api/nn_operator.h
+++ b/xcore/operator_book/lib_nn_operator/api/nn_operator.h
@@ -178,9 +178,7 @@ lower (respectively) 16 bits of the 32-bit bias for output channel `(16*i + j)`.
     \endcode
  *  Note that the fifth dimension of `K` is reversed.
  *
- * The shape of `shifts` is (C_out), with data layed out in standard form.
- * 
- * The shape of `scales` is (C_out), with data layed out in standard form.
+ * The shape of the `scales` tensor is (C_out // 16, 2, 16). The first index is the channel group, second indicates shift (0) or scale (1), and the third is the channel offset within the channel group.
  * 
  * where `X_height`, `X_width`, `C_in`, `C_out`, `K_h` and `K_w` are from the parameters supplied to
  * `conv2d_deepin_deepout_init()`.
@@ -190,7 +188,6 @@ lower (respectively) 16 bits of the 32-bit bias for output channel `(16*i + j)`.
  * \param params    Pointer to `nn_conv2d_dido_params_t` initialized with `conv2d_deepin_deepout_init()`
  * \param X         Pointer to beginning of input data tensor
  * \param K         Pointer to beginning of kernel tensor
- * \param shifts    Pointer to beginning of shifts tensor
  * \param scales    Pointer to beginning of scales tensor
  */
 static inline void conv2d_deepin_deepout(
@@ -198,7 +195,6 @@ static inline void conv2d_deepin_deepout(
     const nn_conv2d_dido_params_t* params,
     const int8_t* X,
     const int8_t* K,
-    const int16_t* shifts,
     const int16_t* scales);
 
 
@@ -258,9 +254,7 @@ static inline void conv2d_deepin_deepout(
  * The shape of `B` is (C_out // 16, 2, 16), and is layed out in Bias Tensor Layout (Form 1) 
  * as described above.
  *
- * The shape of `shifts` is (C_out), with data layed out in standard form.
- * 
- * The shape of `scales` is (C_out), with data layed out in standard form.
+ * The shape of the `scales` tensor is (C_out // 16, 2, 16). The first index is the channel group, second indicates shift (0) or scale (1), and the third is the channel offset within the channel group.
  * 
  * where `X_height`, `X_width`, `C_in`, `C_out`, `K_h` and `K_w` are from the parameters supplied to
  * `conv2d_shallowin_deepout_init()`.
@@ -271,7 +265,6 @@ static inline void conv2d_deepin_deepout(
  * \param X         Pointer to beginning of input data tensor
  * \param K         Pointer to beginning of kernel tensor
  * \param B         Pointer to beginning of bias tensor
- * \param shifts    Pointer to beginning of shifts tensor
  * \param scales    Pointer to beginning of scales tensor
  */
 static inline void conv2d_shallowin_deepout(
@@ -279,7 +272,6 @@ static inline void conv2d_shallowin_deepout(
     const nn_conv2d_sido_params_t* params,
     const int8_t* X,
     const int8_t* K,
-    const int16_t* shifts,
     const int16_t* scales);
 
     
@@ -568,6 +560,25 @@ void conv2d_dido_boggle_K(
     const unsigned K_w,
     const unsigned C_in,
     const unsigned C_out);
+    
+
+/**
+ * Re-layout the shift-scale tensor to the format expected by the convolution kernels.
+ * 
+ * The input tensor should contain all of the shifts followed by all of the scales, in
+ * channel order. 
+ *
+ * A scratch buffer parameter may optionally be supplied (same size as `shiftscales`).
+ * If `scratch` is `NULL`, a buffer will be `malloc`ed (and `free`ed).
+ *
+ * \param shiftscales   The shift/scale tensor. Updated in-place
+ * \param C_out         The number of output channels
+ * \param scratch       Optional scratch buffer.
+ */
+void conv2d_boggle_shift_scale(
+    int16_t* shiftscales,
+    const unsigned C_out,
+    int16_t* scratch);
 
 
 /**

--- a/xcore/operator_book/lib_nn_operator/api/nn_operator_asm.h
+++ b/xcore/operator_book/lib_nn_operator/api/nn_operator_asm.h
@@ -24,7 +24,6 @@ void conv2d_deepin_deepout_block_asm(
     const nn_conv2d_dido_block_params_t* block,
     const int8_t* X,
     const int8_t* K,
-    const int16_t* shifts,
     const int16_t* scales);
 
  
@@ -37,7 +36,6 @@ void conv2d_shallowin_deepout_block_asm(
     const nn_conv2d_sido_block_params_t* block,
     const int8_t* X,
     const int8_t* K,
-    const int16_t* shifts,
     const int16_t* scales);   
 
 #ifndef USE_ASM_fc_deepin_shallowout_16

--- a/xcore/operator_book/lib_nn_operator/api/nn_operator_c.h
+++ b/xcore/operator_book/lib_nn_operator/api/nn_operator_c.h
@@ -20,7 +20,6 @@ void conv2d_deepin_deepout_block_c(
     const nn_conv2d_dido_block_params_t* block,
     const int8_t* X,
     const int8_t* K,
-    const int16_t* shifts,
     const int16_t* scales);
 
 
@@ -30,7 +29,6 @@ void conv2d_shallowin_deepout_block_c(
     const nn_conv2d_sido_block_params_t* block,
     const int8_t* X,
     const int8_t* K,
-    const int16_t* shifts,
     const int16_t* scales);
 
 

--- a/xcore/operator_book/lib_nn_operator/api/nn_operator_inline.h
+++ b/xcore/operator_book/lib_nn_operator/api/nn_operator_inline.h
@@ -22,16 +22,15 @@ static inline void conv2d_deepin_deepout_block(
     const nn_conv2d_dido_block_params_t* block,
     const int8_t* X,
     const int8_t* K,
-    const int16_t* shifts,
     const int16_t* scales)
 {
 #if defined(__XS3A__) && (USE_ASM_conv2d_deepin_deepout_block)
 
-    conv2d_deepin_deepout_block_asm(Y, params, block, X, K, shifts, scales);
+    conv2d_deepin_deepout_block_asm(Y, params, block, X, K, scales);
 
 #else
 
-    conv2d_deepin_deepout_block_c(Y, params, block, X, K, shifts, scales);
+    conv2d_deepin_deepout_block_c(Y, params, block, X, K, scales);
 
 #endif
 }
@@ -41,14 +40,13 @@ static inline void conv2d_deepin_deepout(
     const nn_conv2d_dido_params_t* params,
     const int8_t* X,
     const int8_t* K,
-    const int16_t* shifts,
     const int16_t* scales)
 {
     const unsigned block_count = params->block_count;
     for(int i = 0; i < block_count; i++){
         conv2d_deepin_deepout_block(
             Y, params, &params->blocks[i],
-            X, K, shifts, scales
+            X, K, scales
         );
     }
 }
@@ -60,16 +58,15 @@ static inline void conv2d_shallowin_deepout_block(
     const nn_conv2d_sido_block_params_t* block,
     const int8_t* X,
     const int8_t* K,
-    const int16_t* shifts,
     const int16_t* scales)
 {
 #if defined(__XS3A__) && (USE_ASM_conv2d_shallowin_deepout_block)
 
-    conv2d_shallowin_deepout_block_asm(Y, params, block, X, K, shifts, scales);
+    conv2d_shallowin_deepout_block_asm(Y, params, block, X, K, scales);
 
 #else
 
-    conv2d_shallowin_deepout_block_c(Y, params, block, X, K, shifts, scales);
+    conv2d_shallowin_deepout_block_c(Y, params, block, X, K, scales);
 
 #endif
 }
@@ -80,14 +77,13 @@ static inline void conv2d_shallowin_deepout(
     const nn_conv2d_sido_params_t* params,
     const int8_t* X,
     const int8_t* K,
-    const int16_t* shifts,
     const int16_t* scales)
 {
     const unsigned block_count = params->block_count;
     for(int i = 0; i < block_count; i++){
         conv2d_shallowin_deepout_block(
             Y, params, &params->blocks[i],
-            X, K, shifts, scales
+            X, K, scales
         );
     }
 }

--- a/xcore/operator_book/lib_nn_operator/src/asm/conv2d_deepin_deepout_block.S
+++ b/xcore/operator_book/lib_nn_operator/src/asm/conv2d_deepin_deepout_block.S
@@ -9,7 +9,6 @@ void conv2d_deepin_deepout_block_asm(
     const nn_conv2d_dido_block_params_t* block,
     const int8_t* X,
     const int8_t* K,
-    const int16_t* shifts,
     const int16_t* scales);
 */
 
@@ -34,8 +33,7 @@ void conv2d_deepin_deepout_block_asm(
 #define arg_X                   r3
 
 #define STACK_K_START           (NSTACKWORDS+1)
-#define STACK_SHIFTS_START      (NSTACKWORDS+2)
-#define STACK_SCALES_START      (NSTACKWORDS+3)
+#define STACK_SCALES_START      (NSTACKWORDS+2)
 
 #define STACK_R4_R5_DBL         (1)
 #define STACK_R6_R7_DBL         (2)
@@ -45,8 +43,7 @@ void conv2d_deepin_deepout_block_asm(
 #define STACK_X_START           (8)
 
 #define STACK_B_NEXT            (9)
-#define STACK_SHIFTS_NEXT       (10)
-#define STACK_SCALES_NEXT       (11)
+#define STACK_SCALES_NEXT       (10)
 
 #define STACK_OUT_COLS          (12)
 #define STACK_COUT_GRPS         (13)
@@ -151,13 +148,11 @@ FUNCTION_NAME:
         {                                                   ;   ldw r11, sp[STACK_COUT_GRPS]                    }
         {                                                   ;   stw r11, sp[STACK_COUT_GRPS_LEFT]               }
 
-        //Reset biases, shifts and scales
+        //Reset biases and scales
         {                                                   ;   ldw r2, sp[STACK_B_START]                       }
-        {                                                   ;   ldw r3, sp[STACK_SHIFTS_START]                  }
         {                                                   ;   ldw r4, sp[STACK_SCALES_START]                  }
         
         {                                                   ;   stw r2, sp[STACK_B_NEXT]                        }
-        {                                                   ;   stw r3, sp[STACK_SHIFTS_NEXT]                   }
         {                                                   ;   stw r4, sp[STACK_SCALES_NEXT]                   }
 
         .L_cout_grp_loop:
@@ -234,13 +229,11 @@ FUNCTION_NAME:
             #undef patch_x_row_incr
 
             //Set accumulator mode to 16-bit and saturate accumulators to 16 bits
-            {   shl r11, r10, 3                                 ;   ldw r9, sp[STACK_SHIFTS_NEXT]                   }
-            {                                                   ;   vsetc r11                                       }
-            {   add r9, r9, r10                                 ;   vlsat r9[0]                                     }
-            {                                                   ;   stw r9, sp[STACK_SHIFTS_NEXT]                   }
+            {   shl r11, r10, 3                                 ;   ldw r8, sp[STACK_SCALES_NEXT]                   }
+            {   mkmsk r9, 16                                    ;   vsetc r11                                       }
+            {   add r8, r8, r10                                 ;   vlsat r8[0]                                     }
 
             //Apply scales
-            {   mkmsk r9, 16                                    ;   ldw r8, sp[STACK_SCALES_NEXT]                   }
             {   add r8, r8, r10                                 ;   vlmul r8[0]                                     }
             {   ldc r10, 16                                     ;   stw r8, sp[STACK_SCALES_NEXT]                   }
 

--- a/xcore/operator_book/lib_nn_operator/src/asm/conv2d_shallowin_deepout_block.S
+++ b/xcore/operator_book/lib_nn_operator/src/asm/conv2d_shallowin_deepout_block.S
@@ -9,7 +9,6 @@ void conv2d_shallowin_deepout_block_asm(
     const nn_conv2d_sido_block_params_t* block,
     const int8_t* X,
     const int8_t* K,
-    const int16_t* shifts,
     const int16_t* scales);
 */
 
@@ -34,8 +33,7 @@ void conv2d_shallowin_deepout_block_asm(
 #define arg_X                   r3
 
 #define STACK_K_START           (NSTACKWORDS+1)
-#define STACK_SHIFTS_START      (NSTACKWORDS+2)
-#define STACK_SCALES_START      (NSTACKWORDS+3)
+#define STACK_SCALES_START      (NSTACKWORDS+2)
 
 #define STACK_R4_R5_DBL         (1)
 #define STACK_R6_R7_DBL         (2)
@@ -45,8 +43,7 @@ void conv2d_shallowin_deepout_block_asm(
 #define STACK_X_START           (8)
 
 #define STACK_B_NEXT            (9)
-#define STACK_SHIFTS_NEXT       (10)
-#define STACK_SCALES_NEXT       (11)
+#define STACK_SCALES_NEXT       (10)
 
 #define STACK_OUT_COLS          (12)
 #define STACK_COUT_GRPS         (13)
@@ -158,11 +155,9 @@ FUNCTION_NAME:
 
         //Reset biases, shifts and scales
         {                                                   ;   ldw r2, sp[STACK_B_START]                       }
-        {                                                   ;   ldw r3, sp[STACK_SHIFTS_START]                  }
         {                                                   ;   ldw r4, sp[STACK_SCALES_START]                  }
         
         {                                                   ;   stw r2, sp[STACK_B_NEXT]                        }
-        {                                                   ;   stw r3, sp[STACK_SHIFTS_NEXT]                   }
         {                                                   ;   stw r4, sp[STACK_SCALES_NEXT]                   }
         
         #define pad_mask r4
@@ -253,13 +248,11 @@ FUNCTION_NAME:
             #undef patch_x_row_incr
 
             //Set accumulator mode to 16-bit and saturate accumulators to 16 bits
-            {   shl r11, r10, 3                                 ;   ldw r9, sp[STACK_SHIFTS_NEXT]                   }
-            {                                                   ;   vsetc r11                                       }
-            {   add r9, r9, r10                                 ;   vlsat r9[0]                                     }
-            {                                                   ;   stw r9, sp[STACK_SHIFTS_NEXT]                   }
+            {   shl r11, r10, 3                                 ;   ldw r8, sp[STACK_SCALES_NEXT]                   }
+            {   mkmsk r9, 16                                    ;   vsetc r11                                       }
+            {   add r8, r8, r10                                 ;   vlsat r8[0]                                     }
 
             //Apply scales
-            {   mkmsk r9, 16                                    ;   ldw r8, sp[STACK_SCALES_NEXT]                   }
             {   add r8, r8, r10                                 ;   vlmul r8[0]                                     }
             {   ldc r10, 16                                     ;   stw r8, sp[STACK_SCALES_NEXT]                   }
 

--- a/xcore/operator_book/test/nn_operators/src/test_conv2d_shallowin_deepout.xc
+++ b/xcore/operator_book/test/nn_operators/src/test_conv2d_shallowin_deepout.xc
@@ -74,8 +74,7 @@ void test_conv2d_shallowin_deepout_1x1()
     int8_t  WORD_ALIGNED    K[C_out][K_h][32/C_in][C_in]    = {{{{ 0 }}}};
     int8_t  WORD_ALIGNED    X[X_height][X_width][C_in]      = {{{ 0 }}};
     int32_t WORD_ALIGNED    B[C_out]                        = { 0 };
-    int16_t WORD_ALIGNED    shifts[C_out]                   = { 0 };
-    int16_t WORD_ALIGNED    scales[C_out]                   = { 0 };
+    int16_t WORD_ALIGNED    scales[2][C_out]           = {{ 0 }};
 
 #if TEST_C
     int8_t  WORD_ALIGNED    Y_c[X_height][X_width][C_out]     = {{{ 0 }}};
@@ -184,8 +183,8 @@ void test_conv2d_shallowin_deepout_1x1()
                 if( casse->bias.exp != 0)
                     B[cout] += (1 << (cout + casse->bias.exp));
 
-                shifts[cout] = casse->shift.scale * cout + casse->shift.offset;
-                scales[cout] = casse->scale.scale * cout + casse->scale.offset;
+                scales[0][cout] = casse->shift.scale * cout + casse->shift.offset;
+                scales[1][cout] = casse->scale.scale * cout + casse->scale.offset;
             }
 
             //Set kernel
@@ -216,11 +215,8 @@ void test_conv2d_shallowin_deepout_1x1()
             }
 
             conv2d_sido_boggle_K((int8_t*) K, K_h, VPU_INT8_EPV / C_in, C_in, C_out);
-
-
             conv2d_boggle_B(B, C_out);
-
-            
+            conv2d_boggle_shift_scale((int16_t*)scales, C_out, NULL);
             conv2d_shallowin_deepout_init(&params, &init_params, &region_params, (int8_t*) K, (data16_t* unsafe) B);
 
 
@@ -232,7 +228,7 @@ void test_conv2d_shallowin_deepout_1x1()
             memset(Y_c, 0xCC, sizeof(Y_c));
             for(int block = 0; block < params.block_count; block++){
                 const nn_conv2d_sido_block_params_t* unsafe blk = &params.blocks[block];
-                conv2d_shallowin_deepout_block_c(  (int8_t*)Y_c,     &params, blk, (int8_t*)X, (int8_t*)K, shifts, scales);
+                conv2d_shallowin_deepout_block_c(  (int8_t*)Y_c,     &params, blk, (int8_t*)X, (int8_t*)K, (int16_t*) scales);
             }
     #endif
 
@@ -240,7 +236,7 @@ void test_conv2d_shallowin_deepout_1x1()
             memset(Y_asm, 0xCC, sizeof(Y_asm));
             for(int block = 0; block < params.block_count; block++){
                 const nn_conv2d_sido_block_params_t* unsafe blk = &params.blocks[block];
-                conv2d_shallowin_deepout_block_asm((int8_t*)Y_asm, &params, blk, (int8_t*)X, (int8_t*)K, shifts, scales);
+                conv2d_shallowin_deepout_block_asm((int8_t*)Y_asm, &params, blk, (int8_t*)X, (int8_t*)K, (int16_t*) scales);
             }
     #endif
 
@@ -355,8 +351,7 @@ void test_conv2d_shallowin_deepout_1x1_chans()
     int8_t  WORD_ALIGNED    K[C_out][K_h][32/C_in][C_in]    = {{{{ 0 }}}};
     int8_t  WORD_ALIGNED    X[X_height][X_width][C_in]      = {{{ 0 }}};
     int32_t WORD_ALIGNED    B[C_out]                        = { 0 };
-    int16_t WORD_ALIGNED    shifts[C_out]                   = { 0 };
-    int16_t WORD_ALIGNED    scales[C_out]                   = { 0 };
+    int16_t WORD_ALIGNED    scales[2][C_out]           = {{ 0 }};
 
 #if TEST_C
     int8_t  WORD_ALIGNED    Y_c[X_height][X_width][C_out]     = {{{ 0 }}};
@@ -454,8 +449,8 @@ void test_conv2d_shallowin_deepout_1x1_chans()
                 if( casse->bias.exp != 0)
                     B[cout] += (1 << (cout/4 + casse->bias.exp));
 
-                shifts[cout] = casse->shift.scale * cout/4 + casse->shift.offset;
-                scales[cout] = casse->scale.scale * cout + casse->scale.offset;
+                scales[0][cout] = casse->shift.scale * cout/4 + casse->shift.offset;
+                scales[1][cout] = casse->scale.scale * cout + casse->scale.offset;
             }
 
             //Set kernel
@@ -486,10 +481,8 @@ void test_conv2d_shallowin_deepout_1x1_chans()
             }
             
             conv2d_sido_boggle_K((int8_t*) K, K_h, 32/C_in, C_in, C_out);
-
             conv2d_boggle_B(B, C_out);
-
-
+            conv2d_boggle_shift_scale((int16_t*)scales, C_out, NULL);
             conv2d_shallowin_deepout_init(&params, &init_params, &region_params, (int8_t*) K, (data16_t* unsafe) B);
 
 
@@ -501,7 +494,7 @@ void test_conv2d_shallowin_deepout_1x1_chans()
             memset(Y_c, 0xCC, sizeof(Y_c));
             for(int block = 0; block < params.block_count; block++){
                 const nn_conv2d_sido_block_params_t* unsafe blk = &params.blocks[block];
-                conv2d_shallowin_deepout_block_c(  (int8_t*)Y_c,     &params, blk, (int8_t*)X, (int8_t*)K, shifts, scales);
+                conv2d_shallowin_deepout_block_c(  (int8_t*)Y_c,     &params, blk, (int8_t*)X, (int8_t*)K, (int16_t*) scales);
             }
     #endif
 
@@ -509,7 +502,7 @@ void test_conv2d_shallowin_deepout_1x1_chans()
             memset(Y_asm, 0xCC, sizeof(Y_asm));
             for(int block = 0; block < params.block_count; block++){
                 const nn_conv2d_sido_block_params_t* unsafe blk = &params.blocks[block];
-                conv2d_shallowin_deepout_block_asm((int8_t*)Y_asm, &params, blk, (int8_t*)X, (int8_t*)K, shifts, scales);
+                conv2d_shallowin_deepout_block_asm((int8_t*)Y_asm, &params, blk, (int8_t*)X, (int8_t*)K, (int16_t*) scales);
             }
     #endif
 
@@ -618,8 +611,7 @@ void test_conv2d_shallowin_deepout_1x1_xsize()
     int8_t  WORD_ALIGNED    K[C_out][K_h][32/C_in][C_in]        = {{{{ 0 }}}};
     int8_t  WORD_ALIGNED    X[X_height_max][X_width_max][C_in]  = {{{ 0 }}};
     int32_t WORD_ALIGNED    B[C_out]                            = { 0 };
-    int16_t WORD_ALIGNED    shifts[C_out]                       = { 0 };
-    int16_t WORD_ALIGNED    scales[C_out]                       = { 0 };
+    int16_t WORD_ALIGNED    scales[2][C_out]           = {{ 0 }};
 
 #if TEST_C
     int8_t  WORD_ALIGNED    Y_c[X_height_max][X_width_max][C_out]     = {{{ 0 }}};
@@ -775,8 +767,8 @@ void test_conv2d_shallowin_deepout_1x1_xsize()
                 
                 B[cout]      = casse->bias.scale * cout + casse->bias.offset;
 
-                shifts[cout] = casse->shift.scale * cout + casse->shift.offset;
-                scales[cout] = casse->scale.scale * cout + casse->scale.offset;
+                scales[0][cout] = casse->shift.scale * cout + casse->shift.offset;
+                scales[1][cout] = casse->scale.scale * cout + casse->scale.offset;
             }
 
             //Set kernel
@@ -798,11 +790,8 @@ void test_conv2d_shallowin_deepout_1x1_xsize()
             }
             
             conv2d_sido_boggle_K((int8_t*) K, K_h, VPU_INT8_EPV/C_in, C_in, C_out);
-
-
             conv2d_boggle_B(B, C_out);
-
-            
+            conv2d_boggle_shift_scale((int16_t*)scales, C_out, NULL);
             conv2d_shallowin_deepout_init(&params, &init_params, NULL, (int8_t*) K, (data16_t* unsafe) B);
 
 
@@ -814,7 +803,7 @@ void test_conv2d_shallowin_deepout_1x1_xsize()
             memset(Y_c, OxXX, sizeof(Y_c));
             for(int block = 0; block < params.block_count; block++){
                 const nn_conv2d_sido_block_params_t* unsafe blk = &params.blocks[block];
-                conv2d_shallowin_deepout_block_c(  (int8_t*)Y_c,     &params, blk, (int8_t*)X, (int8_t*)K, shifts, scales);
+                conv2d_shallowin_deepout_block_c(  (int8_t*)Y_c,     &params, blk, (int8_t*)X, (int8_t*)K, (int16_t*) scales);
             }
 #endif
 
@@ -822,7 +811,7 @@ void test_conv2d_shallowin_deepout_1x1_xsize()
             memset(Y_asm, OxXX, sizeof(Y_asm));
             for(int block = 0; block < params.block_count; block++){
                 const nn_conv2d_sido_block_params_t* unsafe blk = &params.blocks[block];
-                conv2d_shallowin_deepout_block_asm((int8_t*)Y_asm, &params, blk, (int8_t*)X, (int8_t*)K, shifts, scales);
+                conv2d_shallowin_deepout_block_asm((int8_t*)Y_asm, &params, blk, (int8_t*)X, (int8_t*)K, (int16_t*) scales);
             }
 #endif
 
@@ -940,8 +929,7 @@ void test_conv2d_shallowin_deepout_3x3()
     int8_t  WORD_ALIGNED    K[C_out][K_h][32/C_in][C_in]    = {{{{ 0 }}}};
     int8_t  WORD_ALIGNED    X[X_height][X_width][C_in]      = {{{ 0 }}};
     int32_t WORD_ALIGNED    B[C_out]                        = { 0 };
-    int16_t WORD_ALIGNED    shifts[C_out]                   = { 0 };
-    int16_t WORD_ALIGNED    scales[C_out]                   = { 0 };
+    int16_t WORD_ALIGNED    scales[2][C_out]           = {{ 0 }};
 
 #if TEST_C
     int8_t  WORD_ALIGNED    Y_c[X_height][X_width][C_out]   = {{{ 0 }}};
@@ -1101,8 +1089,8 @@ void test_conv2d_shallowin_deepout_3x3()
             //Set biases, shifts and scales
             for(int cout = 0; cout < C_out; cout++){
                 B[cout]      = casse->bias;
-                shifts[cout] = casse->shift;
-                scales[cout] = 0x4000;
+                scales[0][cout] = casse->shift;
+                scales[1][cout] = 0x4000;
             }
 
 #if DEBUG_ON
@@ -1139,11 +1127,8 @@ void test_conv2d_shallowin_deepout_3x3()
 #endif
             
             conv2d_sido_boggle_K((int8_t*) K, K_h, VPU_INT8_EPV/C_in, C_in, C_out);
-
-
             conv2d_boggle_B(B, C_out);
-
-            
+            conv2d_boggle_shift_scale((int16_t*)scales, C_out, NULL);
             conv2d_shallowin_deepout_init(&params, &init_params, NULL, (int8_t*) K, (data16_t* unsafe) B);
 
             //Padding mode SAME should have 1 block, mode VALID should have K_h*K_w
@@ -1155,7 +1140,7 @@ void test_conv2d_shallowin_deepout_3x3()
             for(int block = 0; block < params.block_count; block++){
                 const nn_conv2d_sido_block_params_t* unsafe blk = &params.blocks[block];
                 int8_t* Y_targ = (init_params.pad_mode == PADDING_SAME)? (int8_t*)Y_c : (int8_t*) &Y_c[X_height>>1][X_width>>1];
-                conv2d_shallowin_deepout_block_c(  Y_targ,     &params, blk, (int8_t*)X, (int8_t*)K, shifts, scales);
+                conv2d_shallowin_deepout_block_c(  Y_targ,     &params, blk, (int8_t*)X, (int8_t*)K, (int16_t*) scales);
             }
 #endif
 
@@ -1164,7 +1149,7 @@ void test_conv2d_shallowin_deepout_3x3()
             for(int block = 0; block < params.block_count; block++){
                 const nn_conv2d_sido_block_params_t* unsafe blk = &params.blocks[block];
                 int8_t* Y_targ = (init_params.pad_mode == PADDING_SAME)? (int8_t*)Y_asm : (int8_t*) &Y_asm[X_height>>1][X_width>>1];
-                conv2d_shallowin_deepout_block_asm(Y_targ, &params, blk, (int8_t*)X, (int8_t*)K, shifts, scales);
+                conv2d_shallowin_deepout_block_asm(Y_targ, &params, blk, (int8_t*)X, (int8_t*)K, (int16_t*) scales);
             }
 #endif
 
@@ -1306,8 +1291,7 @@ void test_conv2d_shallowin_deepout_regions()
     int8_t  WORD_ALIGNED    K[C_out][K_h][VPU_INT8_EPV/C_in][C_in]        = {{{{ 0 }}}};
     int8_t  WORD_ALIGNED    X[X_height][X_width][C_in]      = {{{ 0 }}};
     int32_t WORD_ALIGNED    B[C_out]                        = { 0 };
-    int16_t WORD_ALIGNED    shifts[C_out]                   = { 0 };
-    int16_t WORD_ALIGNED    scales[C_out]                   = { 0 };
+    int16_t WORD_ALIGNED    scales[2][C_out]           = {{ 0 }};
 
 #if TEST_C
     int8_t  WORD_ALIGNED    Y_c[X_height][X_width][C_out]   = {{{ 0 }}};
@@ -1372,8 +1356,8 @@ void test_conv2d_shallowin_deepout_regions()
         //Set biases, shifts and scales
         for(int cout = 0; cout < C_out; cout++){
             B[cout]      = 0x0100;
-            shifts[cout] = 0;
-            scales[cout] = 0x4000;
+            scales[0][cout] = 0;
+            scales[1][cout] = 0x4000;
         }
 
         //Set kernel
@@ -1384,6 +1368,7 @@ void test_conv2d_shallowin_deepout_regions()
         //No need to boggle K, all values are zero.
         // conv2d_sido_boggle_K((int8_t*) K, K_h, K_w, C_in, C_out);
         conv2d_boggle_B(B, C_out);
+        conv2d_boggle_shift_scale((int16_t*)scales, C_out, NULL);
         conv2d_shallowin_deepout_init(&params, &init_params, &reg, (int8_t*) K, (data16_t* unsafe) B);
 
         //Perform the actual convolution(s)   (run both C and ASM before checking either)
@@ -1393,7 +1378,7 @@ void test_conv2d_shallowin_deepout_regions()
         for(int block = 0; block < params.block_count; block++){
             // PRINTF("\t\t\tblock %d...\n", block);
             const nn_conv2d_sido_block_params_t* unsafe blk = &params.blocks[block];
-            conv2d_shallowin_deepout_block_c( (int8_t*) Y_c, &params, blk, (int8_t*)X, (int8_t*)K, shifts, scales);
+            conv2d_shallowin_deepout_block_c( (int8_t*) Y_c, &params, blk, (int8_t*)X, (int8_t*)K, (int16_t*) scales);
         }
 #endif
 
@@ -1403,7 +1388,7 @@ void test_conv2d_shallowin_deepout_regions()
         for(int block = 0; block < params.block_count; block++){
             // PRINTF("\t\t\tblock %d...\n", block);
             const nn_conv2d_sido_block_params_t* unsafe blk = &params.blocks[block];
-            conv2d_shallowin_deepout_block_asm( (int8_t*) Y_asm, &params, blk, (int8_t*)X, (int8_t*)K, shifts, scales);
+            conv2d_shallowin_deepout_block_asm( (int8_t*) Y_asm, &params, blk, (int8_t*)X, (int8_t*)K, (int16_t*) scales);
         }
 #endif
 


### PR DESCRIPTION

- issue #55 - shift and scale tensors were merged into a single tensor, slightly speeding up the conv2D kernels

Wait to merge until:
 -  PR #56 has been merged (this branch has feature/issue55_requant as a parent)
 - @keithm-xmos implements corresponding changes in the TF Lite custom operator wrappers.