### PR TITLE
fix behavior of Tensor.shape

### DIFF
--- a/tflite2xcore/tflite2xcore/parallelization.py
+++ b/tflite2xcore/tflite2xcore/parallelization.py
@@ -90,9 +90,9 @@ class ParallelizationPlanner(ABC):
 class UnidirectionalSplitPlanner(ParallelizationPlanner):
     def __init__(self, height, width, **kwargs):
         super().__init__(**kwargs)
-        assert isinstance(height, int)
-        assert isinstance(width, int)
-        assert height * width > 0
+        assert isinstance(height, int), f"received height={height} with type {type(height)}"
+        assert isinstance(width, int), f"received width={width} with type {type(width)}"
+        assert height * width > 0, f"received height={height}, width={width}"
         self.height, self.width = height, width
 
     _adjustments = {
@@ -162,4 +162,3 @@ class DIDOConv2DPlanner(UnidirectionalSplitPlanner):
             #       and one block without any edges
             # do this with both horizontal and vertical orientation
             pass
-    

--- a/tflite2xcore/tflite2xcore/serialization/flatbuffers_c.py
+++ b/tflite2xcore/tflite2xcore/serialization/flatbuffers_c.py
@@ -116,6 +116,8 @@ class FlexbufferBuilder:
                 self.__add_map(obj, value, key_ascii)
             elif value_type == list:
                 self.__add_vector(obj, value, key_ascii)
+            elif value_type == tuple:
+                self.__add_vector(obj, list(value), key_ascii)
             else:
                 raise Exception(f'Type {value_type} not supported (key={key_ascii}, value={value})')
 

--- a/tflite2xcore/tflite2xcore/serialization/flatbuffers_io.py
+++ b/tflite2xcore/tflite2xcore/serialization/flatbuffers_io.py
@@ -139,7 +139,7 @@ def create_xcore_model(modelT):
             tensor = subgraph.create_tensor(
                 name=tensorT.name.decode('utf-8'),
                 type_=TensorType(tensorT.type),
-                shape=list(tensorT.shape.tolist() if tensorT.shape is not None else []),
+                shape=tensorT.shape,
                 buffer=buffers[tensorT.buffer],
                 quantization=quantization,
                 isinput=is_input,

--- a/tflite2xcore/tflite2xcore/tests/test_serialization/test_flatbuffer_io.py
+++ b/tflite2xcore/tflite2xcore/tests/test_serialization/test_flatbuffer_io.py
@@ -46,7 +46,7 @@ def test_read_flatbuffer():
     assert tensor.sanitized_name == 'arm_benchmark_conv2d_Conv2D_bias'
     assert tensor.type == TensorType.INT32
     assert tensor.standard_type == 'int32_t'
-    assert tensor.shape == [32]
+    assert tensor.shape == (32,)
     assert len(tensor.buffer.data) == 128
 
     operator = subgraph.operators[1]

--- a/tflite2xcore/tflite2xcore/tests/test_transformation_passes/test_AddArgMax16OutputPass.py
+++ b/tflite2xcore/tflite2xcore/tests/test_transformation_passes/test_AddArgMax16OutputPass.py
@@ -84,7 +84,7 @@ def test_mutate(model, trf_pass):
 
     dim_tensor = argmax_input_tensors[1]
     assert dim_tensor.type == TensorType.INT32
-    assert dim_tensor.shape == []
+    assert len(dim_tensor.shape) == 0
     assert dim_tensor.numpy == 1
 
 

--- a/tflite2xcore/tflite2xcore/tests/test_transformation_passes/test_lut_passes/conftest.py
+++ b/tflite2xcore/tflite2xcore/tests/test_transformation_passes/test_lut_passes/conftest.py
@@ -92,4 +92,4 @@ def test_mutate(trf_pass, model):
     # check LUT shape
     lut_tensor = op.inputs[1]
     assert len(lut_tensor.buffer.data) == 256
-    assert lut_tensor.shape == [256]
+    assert lut_tensor.shape == (256,)

--- a/tflite2xcore/tflite2xcore/transformation_passes/conv2d_passes.py
+++ b/tflite2xcore/tflite2xcore/transformation_passes/conv2d_passes.py
@@ -222,7 +222,7 @@ class ReplaceDeepoutConv2DInputPass(ReplaceDeepoutConv2DPass):
         #       keep in mind that this mutation is what can affect other operators
         with self.using(op):
             self._input.name = f"{op.name}/input"
-            self._input.shape[3] = self.MAX_INPUT_CHANNELS  # new, zero-padded shape
+            self._input.shape = [*self._input.shape[:3], self.MAX_INPUT_CHANNELS]  # new, zero-padded shape
 
     def mutate_weights(self, op):
         super().mutate_weights(op)


### PR DESCRIPTION
The most important change is that Tensor.shape will always return a tuple. Moreover, it can now be set with None, tuple, list, or numpy.ndarray.

Also, flexbuffers can now handle tuples (the same way as lists).