### PR TITLE
ensured safe usage of Subpgraph.remove_tensor

### DIFF
--- a/tflite2xcore/tflite2xcore/transformation_passes/quantize_dequantize_passes.py
+++ b/tflite2xcore/tflite2xcore/transformation_passes/quantize_dequantize_passes.py
@@ -15,6 +15,7 @@ class CanonicalizeQuantizedInputPass(OperatorMatchingPass):
             input_tensor, output_tensor = op.inputs[0], op.outputs[0]
             return (
                 input_tensor in op.subgraph.inputs
+                and len(input_tensor.consumers) == 1
                 and output_tensor not in op.subgraph.outputs
                 and output_tensor.type is TensorType.INT8
                 and input_tensor.type is TensorType.FLOAT32
@@ -25,7 +26,7 @@ class CanonicalizeQuantizedInputPass(OperatorMatchingPass):
     def mutate(self, op):
         subgraph = op.subgraph
         subgraph.inputs.append(op.outputs[0])
-        subgraph.remove_tensor(op.inputs[0])
+        subgraph.remove_tensor(op.inputs[0])  # DCE doesn't clean up subgraph inputs
         subgraph.remove_operator(op)
 
 
@@ -33,20 +34,27 @@ class CanonicalizeQuantizedOutputPass(OperatorMatchingPass):
     def match(self, op):
         if super().match(op) and op.operator_code.code is BuiltinOpCodes.DEQUANTIZE:
             input_tensor, output_tensor = op.inputs[0], op.outputs[0]
-            return (
+            if (
                 output_tensor in op.subgraph.outputs
                 and not output_tensor.consumers
                 and input_tensor not in op.subgraph.inputs
                 and output_tensor.type is TensorType.FLOAT32
                 and input_tensor.type is TensorType.INT8
-            )
+            ):
+                if len(output_tensor.producers) == 1:
+                    return True
+                else:
+                    self.logger.warning(
+                        "Encountered output of removable DEQUANTIZE "
+                        "with more than one producer."
+                    )
 
         return False
 
     def mutate(self, op):
         subgraph = op.subgraph
         subgraph.outputs.append(op.inputs[0])
-        subgraph.remove_tensor(op.outputs[0])
+        subgraph.remove_tensor(op.outputs[0])  # DCE doesn't clean up subgraph outputs
         subgraph.remove_operator(op)
 
 


### PR DESCRIPTION
While looking at the implementation of some existing passes, I noticed that `tflite2xcore.xcore_model.Subgraph.remove_tensor` is sometimes used in a potentially unsafe manner. Generally, op replacement/removal passes should leave tensor removal to the DCE passes, with the exception of passes that mutate the subgraph inputs/outputs (since DCE will not modify the inputs/outputs). In this case, however, the pass should ensure that  no other op depends on the tensor to be removed, usually by checking consumers/producers. This PR fixes these, and adds comments where remove tensor needs to be used explicitly.