### PR TITLE
Fix global average pool sometimes being off-by-2

### DIFF
--- a/tflite2xcore/tflite2xcore/transformation_passes/pooling_passes.py
+++ b/tflite2xcore/tflite2xcore/transformation_passes/pooling_passes.py
@@ -151,11 +151,12 @@ class ReplaceGlobalAveragePool2DPass(ReplaceQuantizedOperatorPass):
         scale = np.round(multiplier * 2 ** (7 - np.ceil(np.log2(multiplier))))
         shift = np.round(np.log2(scale / multiplier))
         bias = np.round(
-            scale
-            * (
-                self._output.quantization["zero_point"][0] / multiplier
-                - self._input.quantization["zero_point"][0] * num_pixels
+            (
+                self._output.quantization["zero_point"][0]
+                - self._input.quantization["zero_point"][0] * rescaling
+                + 0.5  # needed because the tflite ref adds 0.5 to the bias
             )
+            * 2 ** shift
         )
 
         if shift > 24:

--- a/utils/model_generation/integration_test/__init__.py
+++ b/utils/model_generation/integration_test/__init__.py
@@ -179,11 +179,11 @@ def _test_batched_arrays(
     assert issubclass(predicted.dtype.type, np.integer)  # TODO: generalize to floats
 
     failures: Dict[int, List[FailedElement]] = {}
-    diffs = np.abs(np.int32(predicted) - np.int32(expected))
+    diffs = np.int32(predicted) - np.int32(expected)
     for j, (arr, arr_ref, diff) in enumerate(zip(predicted, expected, diffs)):
         __log_deviations(diff, logging.DEBUG, ex_idx=j)
 
-        diff_idx = zip(*np.where(diff > tolerance))
+        diff_idx = zip(*np.where(np.abs(diff > tolerance)))
         failed_examples = [
             FailedElement(idx, diff[idx], arr_ref[idx], arr[idx]) for idx in diff_idx
         ]

--- a/utils/model_generation/integration_test/conftest.py
+++ b/utils/model_generation/integration_test/conftest.py
@@ -53,7 +53,7 @@ def pytest_addoption(parser):  # type: ignore
 def pytest_generate_tests(metafunc: _pytest.python.Metafunc) -> None:
     if "run" in metafunc.fixturenames:
         try:
-            CONFIGS = metafunc.module.CONFIGS  # [coverage].values()
+            CONFIGS = metafunc.module.CONFIGS
             config_file = Path(metafunc.module.__file__)
         except AttributeError:
             logging.debug(f"CONFIGS undefined in {metafunc.module}")

--- a/utils/model_generation/integration_test/test_single_op_models/test_pool2d/test_global_avgpool2d.py
+++ b/utils/model_generation/integration_test/test_single_op_models/test_pool2d/test_global_avgpool2d.py
@@ -8,7 +8,7 @@ from tflite2xcore.xcore_schema import XCOREOpCodes  # type: ignore # TODO: fix t
 
 from . import (
     ChannelPreservingOpTestModelGenerator,
-    test_output as _test_output,
+    test_output,
     test_converted_single_op_model,
     test_idempotence,
 )
@@ -38,17 +38,6 @@ GENERATOR = GlobalAveragePooling2dTestModelGenerator
 @pytest.fixture  # type: ignore
 def converted_op_code() -> XCOREOpCodes:
     return XCOREOpCodes.XC_avgpool2d_global
-
-
-#  ----------------------------------------------------------------------------
-#                                   TESTS
-#  ----------------------------------------------------------------------------
-
-# TODO: fix this when issue #143 is fixed
-def test_output(run, request):  # type: ignore
-    if request.node.name in ("test_output[CONFIGS[34]]"):
-        request.applymarker(pytest.mark.xfail(run=False))
-    _test_output(run, request)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #143 and improves accuracy of the global average pooling kernel. Changes only affect the xformer.