### PR TITLE
Increased size of tensor arena to 64M

### DIFF
--- a/tflite2xcore/tflite2xcore/interpreters/xcore_interpreter.py
+++ b/tflite2xcore/tflite2xcore/interpreters/xcore_interpreter.py
@@ -7,7 +7,7 @@ from enum import Enum
 from tflite2xcore import libtflite2xcore as lib
 
 
-MAX_TENSOR_ARENA_SIZE = 1000000
+MAX_TENSOR_ARENA_SIZE = 64 * 1000000
 
 
 class XCOREInterpreterStatus(Enum):


### PR DESCRIPTION
Also, cleaner handling if 64MB is not big enough.  

Addresses issue https://github.com/xmos/ai_tools/issues/134.  Except, the warning if the arena exceeds 512K will be added to the project generation scripts as this is a target specific limit.  