### PR TITLE
added support for version info

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -175,6 +175,7 @@ dependencies:
     - requests-oauthlib==1.3.0
     - rsa==4.0
     - scipy==1.4.1
+    - setuptools_scm==4.1.2
     - tensorboard==2.3.0
     - tensorflow==2.3.0
     - tensorflow-datasets==3.2.1

--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -194,6 +194,7 @@ dependencies:
     - requests-oauthlib==1.3.0
     - rsa==4.0
     - scipy==1.4.1
+    - setuptools_scm==4.1.2
     - shellingham==1.3.1
     - tensorboard==2.3.0
     - tensorflow-datasets==3.2.1

--- a/tflite2xcore/setup.py
+++ b/tflite2xcore/setup.py
@@ -21,7 +21,6 @@ INSTALL_REQUIRES = [
 
 setuptools.setup(
     name="tflite2xcore",
-    version="0.1.1",
     packages=setuptools.find_packages(exclude=EXCLUDES),
     scripts=SCRIPTS,
     python_requires=">=3.6.8",
@@ -32,4 +31,10 @@ setuptools.setup(
     description="XMOS Tools to convert TensorFlow Lite models to xCORE microcontrollers.",
     license="LICENSE.txt",
     keywords="xmos xcore",
+    use_scm_version={
+        "root": "..",
+        "relative_to": __file__,
+        "version_scheme": "post-release",
+    },
+    setup_requires=["setuptools_scm"],
 )

--- a/tflite2xcore/tflite2xcore/__init__.py
+++ b/tflite2xcore/tflite2xcore/__init__.py
@@ -1,6 +1,7 @@
-# Copyright (c) 2018-2020, XMOS Ltd, All rights reserved1
+# Copyright (c) 2018-2020, XMOS Ltd, All rights reserved
 import sys
 import ctypes
+
 from pathlib import Path
 
 __PARENT_DIR = Path(__file__).parent.absolute()
@@ -12,6 +13,10 @@ else:
     raise RuntimeError("tflite2xcore is not yet supported on Windows!")
 
 libtflite2xcore = ctypes.cdll.LoadLibrary(lib_path)
+
+from . import version
+
+__version__ = version.get_version()
 
 from . import xcore_schema
 from . import xcore_model

--- a/tflite2xcore/tflite2xcore/version.py
+++ b/tflite2xcore/tflite2xcore/version.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2018-2020, XMOS Ltd, All rights reserved
+
+
+def get_version() -> str:
+    try:
+        # use setuptools_scm if installed
+        #   setuptools_scm will append commit info the base version number
+        from setuptools_scm import get_version
+
+        return get_version(
+            root="../..", relative_to=__file__, version_scheme="post-release"
+        )
+    except:
+        # fall back to the builtin importlib_metadata module
+        #   importlib_metadata returns the version number in the package metadata
+        from importlib_metadata import version
+
+        return version(__name__)

--- a/tflite2xcore/xformer.py
+++ b/tflite2xcore/xformer.py
@@ -4,9 +4,8 @@
 
 from pathlib import Path
 
-from tflite2xcore import utils, analyze
+from tflite2xcore import utils, analyze, version
 import tflite2xcore.converter as xcore_conv
-
 
 if __name__ == "__main__":
     parser = utils.VerbosityParser()
@@ -39,6 +38,13 @@ if __name__ == "__main__":
         help="Analyze the output model. "
         "A report is printed showing the runtime memory footprint of the model.",
     )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=version.get_version(),
+        help="Display the version of the xformer",
+    )
+
     args = parser.parse_args()
 
     utils.set_verbosity(args.verbose)


### PR DESCRIPTION
Added support for  `tflite2xcore.__version__` and `xformer.py --version`.  These use the most recent git release tag for the base semantic version (x.y.z).  

If you have installed the `tflite2xcore` module from the repository and are using the Conda environment or have `setuptools_scm` installed, the base semantic version string will be appended with additional information - like how many commits you are ahead of the release tag, your most recent local commit hash, and the date.