### PR TITLE
Feature/bconv2d activation tests

### DIFF
--- a/test/model_generation/generate.ipynb
+++ b/test/model_generation/generate.ipynb
@@ -1511,6 +1511,63 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# test_bconv2d_int8_activation.yml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params = dict(\n",
+    "    height=[7, 10, 12],\n",
+    "    width=[6, 8, 11],\n",
+    "    K_h=[1,2,3,6],\n",
+    "    K_w=[1,3,4,5],\n",
+    "    input_channels=[32, 128, 256+64],\n",
+    "    output_channels=[4, 28, 32],\n",
+    "    strides=[(1,1), (1,2), (2,1), (2,2)],\n",
+    "    output_range = [(range_min, range_max) for range_min in range(-4, 1, 2) for range_max in range(1, 6, 2)],\n",
+    "    activation = [\"relu\", \"relu6\"],\n",
+    "#     num_threads=[1,2,5],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "20"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
+    "len(configs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dump_configs(configs, \"test_bconv2d_int8_activation.yml\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_bin.py
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_bin.py
@@ -28,9 +28,10 @@ from . import (  # pylint: disable=unused-import
 class BConv2dBitpackedTestModelGenerator(BConv2dGenericTestModelGenerator):
     def _set_config(self, cfg: Configuration) -> None:
         cfg.setdefault("padding", "valid")
-        assert (
-            "output_range" not in cfg
-        ), f"output_range cannot be specified for BConv2dBitpacked tests"
+        for forbidden_key in ("activation", "output_range"):
+            assert (
+                forbidden_key not in cfg
+            ), f"{forbidden_key} cannot be specified for BConv2dBitpacked tests"
         super()._set_config(cfg)
 
     def check_config(self) -> None:

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_activation.py
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_activation.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2020, XMOS Ltd, All rights reserved
+
+import pytest
+
+pytestmark = pytest.mark.skip  # TODO: remove this when kernel bugs are fixed
+
+from tflite2xcore.xcore_schema import ExternalOpCodes, XCOREOpCodes  # type: ignore # TODO: fix this
+from tflite2xcore.model_generation import Configuration
+
+from .test_bconv2d_int8 import (  # pylint: disable=unused-import
+    GENERATOR,
+    RUNNER,
+    bitpacked_outputs,
+    reference_op_code,
+    converted_op_code,
+)
+
+from . import (  # pylint: disable=unused-import
+    test_reference_model_regression,
+    test_converted_single_op_model,
+    test_output,
+)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_activation.yml
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_activation.yml
@@ -1,0 +1,283 @@
+# Copyright (c) 2020, XMOS Ltd, All rights reserved
+# RANDOMLY GENERATED CONFIGS, MODIFY AT OWN RISK
+default:
+  0:
+    K_h: 1
+    K_w: 4
+    activation: relu
+    height: 10
+    input_channels: 32
+    output_channels: 32
+    output_range:
+    - 0
+    - 3
+    strides:
+    - 1
+    - 1
+    width: 8
+  1:
+    K_h: 6
+    K_w: 1
+    activation: relu6
+    height: 7
+    input_channels: 128
+    output_channels: 32
+    output_range:
+    - -2
+    - 1
+    strides:
+    - 1
+    - 2
+    width: 11
+  2:
+    K_h: 6
+    K_w: 3
+    activation: relu
+    height: 10
+    input_channels: 32
+    output_channels: 32
+    output_range:
+    - -4
+    - 3
+    strides:
+    - 1
+    - 1
+    width: 8
+  3:
+    K_h: 6
+    K_w: 4
+    activation: relu6
+    height: 12
+    input_channels: 128
+    output_channels: 28
+    output_range:
+    - -2
+    - 1
+    strides:
+    - 1
+    - 2
+    width: 6
+  4:
+    K_h: 1
+    K_w: 3
+    activation: relu6
+    height: 12
+    input_channels: 320
+    output_channels: 32
+    output_range:
+    - -4
+    - 5
+    strides:
+    - 1
+    - 2
+    width: 11
+  5:
+    K_h: 6
+    K_w: 1
+    activation: relu
+    height: 7
+    input_channels: 32
+    output_channels: 4
+    output_range:
+    - -2
+    - 1
+    strides:
+    - 2
+    - 2
+    width: 6
+  6:
+    K_h: 3
+    K_w: 5
+    activation: relu
+    height: 7
+    input_channels: 32
+    output_channels: 28
+    output_range:
+    - 0
+    - 1
+    strides:
+    - 1
+    - 1
+    width: 11
+  7:
+    K_h: 1
+    K_w: 1
+    activation: relu
+    height: 7
+    input_channels: 320
+    output_channels: 28
+    output_range:
+    - -2
+    - 5
+    strides:
+    - 2
+    - 2
+    width: 8
+  8:
+    K_h: 2
+    K_w: 5
+    activation: relu6
+    height: 10
+    input_channels: 320
+    output_channels: 28
+    output_range:
+    - -2
+    - 3
+    strides:
+    - 2
+    - 2
+    width: 8
+  9:
+    K_h: 2
+    K_w: 1
+    activation: relu6
+    height: 10
+    input_channels: 128
+    output_channels: 4
+    output_range:
+    - -4
+    - 1
+    strides:
+    - 1
+    - 1
+    width: 8
+  10:
+    K_h: 3
+    K_w: 1
+    activation: relu
+    height: 12
+    input_channels: 320
+    output_channels: 4
+    output_range:
+    - 0
+    - 1
+    strides:
+    - 2
+    - 1
+    width: 11
+  11:
+    K_h: 3
+    K_w: 4
+    activation: relu
+    height: 12
+    input_channels: 320
+    output_channels: 32
+    output_range:
+    - -4
+    - 1
+    strides:
+    - 1
+    - 1
+    width: 8
+  12:
+    K_h: 1
+    K_w: 4
+    activation: relu
+    height: 7
+    input_channels: 128
+    output_channels: 32
+    output_range:
+    - 0
+    - 5
+    strides:
+    - 2
+    - 2
+    width: 11
+  13:
+    K_h: 3
+    K_w: 5
+    activation: relu6
+    height: 10
+    input_channels: 32
+    output_channels: 4
+    output_range:
+    - -2
+    - 5
+    strides:
+    - 2
+    - 2
+    width: 6
+  14:
+    K_h: 6
+    K_w: 4
+    activation: relu6
+    height: 12
+    input_channels: 32
+    output_channels: 4
+    output_range:
+    - -2
+    - 5
+    strides:
+    - 1
+    - 2
+    width: 11
+  15:
+    K_h: 2
+    K_w: 3
+    activation: relu
+    height: 10
+    input_channels: 320
+    output_channels: 4
+    output_range:
+    - -2
+    - 3
+    strides:
+    - 2
+    - 1
+    width: 11
+  16:
+    K_h: 2
+    K_w: 5
+    activation: relu6
+    height: 10
+    input_channels: 128
+    output_channels: 32
+    output_range:
+    - -4
+    - 1
+    strides:
+    - 2
+    - 1
+    width: 6
+  17:
+    K_h: 2
+    K_w: 3
+    activation: relu6
+    height: 7
+    input_channels: 128
+    output_channels: 28
+    output_range:
+    - -4
+    - 5
+    strides:
+    - 2
+    - 1
+    width: 8
+  18:
+    K_h: 3
+    K_w: 3
+    activation: relu6
+    height: 12
+    input_channels: 320
+    output_channels: 28
+    output_range:
+    - 0
+    - 5
+    strides:
+    - 2
+    - 1
+    width: 6
+  19:
+    K_h: 1
+    K_w: 5
+    activation: relu
+    height: 7
+    input_channels: 128
+    output_channels: 4
+    output_range:
+    - 0
+    - 3
+    strides:
+    - 1
+    - 2
+    width: 6

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bsign.py
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bsign.py
@@ -28,7 +28,7 @@ from . import (  # pylint: disable=unused-import
 
 class BSignTestModelGenerator(LarqCompositeTestModelGenerator):
     def _set_config(self, cfg: Configuration) -> None:
-        for key in ("K_w", "K_h", "output_channels"):
+        for key in ("K_w", "K_h", "output_channels", "activation"):
             assert key not in cfg, f"{key} should not be specified for bsign tests"
         cfg["output_channels"] = 32
         cfg["K_w"] = cfg["K_h"] = 1


### PR DESCRIPTION
This PR adds single operator integration tests for bconv2d kernels with fused relu and relu6 activations. The tests are disabled until some modifications are applied to the bnn kernels.