### PR TITLE
Replace pytest.mark.skip with xfail where appropriate

### DIFF
--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/padded/test_bconv2d_int8_padded.py
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/padded/test_bconv2d_int8_padded.py
@@ -24,7 +24,7 @@ from . import (  # pylint: disable=unused-import
 def test_output(compared_outputs, request):
     name = request.node.name
     if name.endswith("[CONFIGS[13]]") or name.endswith("[CONFIGS[20]]"):
-        pytest.skip()
+        request.applymarker(pytest.mark.xfail(run=False))
     _test_output(compared_outputs, request)
 
 

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/padded/test_bconv2d_int8_padded.py
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/padded/test_bconv2d_int8_padded.py
@@ -23,7 +23,7 @@ from . import (  # pylint: disable=unused-import
 # TODO: remove this when bug is fixed
 def test_output(compared_outputs, request):
     name = request.node.name
-    if name.endswith("[CONFIGS[13]]") or name.endswith("[CONFIGS[20]]"):
+    if name.endswith("[CONFIGS[13]]") or name.endswith("[CONFIGS[19]]"):
         request.applymarker(pytest.mark.xfail(run=False))
     _test_output(compared_outputs, request)
 

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/padded/test_bconv2d_int8_padded.yml
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/padded/test_bconv2d_int8_padded.yml
@@ -268,20 +268,6 @@ default:
     - 1
     width: 6
   19:
-    K_h: 3
-    K_w: 4
-    height: 12
-    input_channels: 128
-    output_channels: 4
-    output_range:
-    - -2
-    - 1
-    padding: same
-    strides:
-    - 1
-    - 2
-    width: 11
-  20: # TODO: delete this case
     K_h: 32
     K_w: 1
     height: 32

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_activation.py
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_activation.py
@@ -2,11 +2,6 @@
 
 import pytest
 
-pytestmark = pytest.mark.skip  # TODO: remove this when kernel bugs are fixed
-
-from tflite2xcore.xcore_schema import ExternalOpCodes, XCOREOpCodes  # type: ignore # TODO: fix this
-from tflite2xcore.model_generation import Configuration
-
 from .test_bconv2d_int8 import (  # pylint: disable=unused-import
     GENERATOR,
     RUNNER,
@@ -18,8 +13,21 @@ from .test_bconv2d_int8 import (  # pylint: disable=unused-import
 from . import (  # pylint: disable=unused-import
     test_reference_model_regression,
     test_converted_single_op_model,
-    test_output,
+    test_output as _test_output,
 )
+
+#  ----------------------------------------------------------------------------
+#                                   TESTS
+#  ----------------------------------------------------------------------------
+
+# TODO: remove this when bug is fixed
+def test_output(compared_outputs, request):
+    name = request.node.name
+    for config_idx in (1, 2, 3, 4, 5, 7, 8, 9, 11, 13, 14, 15, 16, 17):
+        config_str = f"[CONFIGS[{config_idx}]]"
+        if name.endswith(config_str):
+            request.applymarker(pytest.mark.xfail(run=False))
+    _test_output(compared_outputs, request)
 
 
 if __name__ == "__main__":

--- a/test/model_generation/integration_test/test_single_op_models/test_pool2d/test_global_avgpool2d.py
+++ b/test/model_generation/integration_test/test_single_op_models/test_pool2d/test_global_avgpool2d.py
@@ -35,6 +35,20 @@ GENERATOR = GlobalAveragePooling2dTestModelGenerator
 #  ----------------------------------------------------------------------------
 
 
+@pytest.fixture  # type: ignore
+def converted_op_code() -> XCOREOpCodes:
+    return XCOREOpCodes.XC_avgpool2d_global
+
+
+@pytest.fixture  # type: ignore
+def reference_op_code() -> BuiltinOpCodes:
+    return BuiltinOpCodes.MEAN
+
+
+#  ----------------------------------------------------------------------------
+#                                   TESTS
+#  ----------------------------------------------------------------------------
+
 # TODO: fix this
 def test_output(compared_outputs, request):
     name = request.node.name
@@ -44,18 +58,8 @@ def test_output(compared_outputs, request):
             or name.endswith("[CONFIGS[16]]")
             or name.endswith("[CONFIGS[21]]")
         ):
-            pytest.skip()
+            request.applymarker(pytest.mark.xfail(run=False))
     _test_output(compared_outputs, request)
-
-
-@pytest.fixture  # type: ignore
-def converted_op_code() -> XCOREOpCodes:
-    return XCOREOpCodes.XC_avgpool2d_global
-
-
-@pytest.fixture  # type: ignore
-def reference_op_code() -> BuiltinOpCodes:
-    return BuiltinOpCodes.MEAN
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Xfail is more appropriate for tests that should be fixed, but are disabled while their fix is being implemented.