### PR TITLE
enable correct conversion of arbitrary bconv2d fused activation functions

### DIFF
--- a/test/model_generation/generate.ipynb
+++ b/test/model_generation/generate.ipynb
@@ -1568,6 +1568,63 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# test_bconv2d_int8_DIDO_activation.yml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params = dict(\n",
+    "    height=[7, 10, 12],\n",
+    "    width=[6, 8, 11],\n",
+    "    K_h=[1,2,3,6],\n",
+    "    K_w=[1,3,4,5],\n",
+    "    input_channels=[256,512],\n",
+    "    output_channels=[16, 48],\n",
+    "    strides=[(1,1), (1,2), (2,1), (2,2)],\n",
+    "    output_range = [(range_min, range_max) for range_min in range(-4, 1, 2) for range_max in range(1, 6, 2)],\n",
+    "    activation = [\"relu\", \"relu6\"],\n",
+    "#     num_threads=[1,2,5],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "20"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
+    "len(configs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dump_configs(configs, \"test_bconv2d_int8_DIDO_activation.yml\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/test/model_generation/integration_test/test_directed/test_bnn.py
+++ b/test/model_generation/integration_test/test_directed/test_bnn.py
@@ -91,7 +91,7 @@ def test_converted_model(xcore_model: XCOREModel) -> None:
     subgraph = xcore_model.subgraphs[0]
 
     # check tensors
-    assert len(subgraph.tensors) == 22
+    assert len(subgraph.tensors) == 23
 
     assert len(subgraph.inputs) == 1
     input_tensor = subgraph.inputs[0]

--- a/test/model_generation/integration_test/test_directed/test_bnn.py
+++ b/test/model_generation/integration_test/test_directed/test_bnn.py
@@ -5,7 +5,7 @@ import logging
 import tensorflow as tf
 import numpy as np
 from pathlib import Path
-from typing import Optional, NamedTuple, Type
+from typing import Optional, Type
 from tflite2xcore.utils import LoggingContext  # type: ignore # TODO: fix this
 from tflite2xcore.xcore_schema import (  # type: ignore # TODO: fix this
     XCOREModel,

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/padded/test_bconv2d_int8_padded.py
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/padded/test_bconv2d_int8_padded.py
@@ -13,19 +13,8 @@ from ..test_bconv2d_int8 import (  # pylint: disable=unused-import
 from . import (  # pylint: disable=unused-import
     test_reference_model_regression,
     test_converted_model,
-    test_output as _test_output,
+    test_output,
 )
-
-#  ----------------------------------------------------------------------------
-#                                   TESTS
-#  ----------------------------------------------------------------------------
-
-# TODO: remove this when bug is fixed
-def test_output(compared_outputs, request):
-    name = request.node.name
-    if name.endswith("[CONFIGS[13]]") or name.endswith("[CONFIGS[19]]"):
-        request.applymarker(pytest.mark.xfail(run=False))
-    _test_output(compared_outputs, request)
 
 
 if __name__ == "__main__":

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO.py
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO.py
@@ -12,7 +12,7 @@ from .test_bconv2d_int8 import (  # pylint: disable=unused-import
 from . import (  # pylint: disable=unused-import
     test_reference_model_regression,
     test_converted_single_op_model,
-    test_output as _test_output,
+    test_output,
 )
 
 
@@ -48,20 +48,6 @@ def reference_op_code() -> ExternalOpCodes:
 @pytest.fixture  # type: ignore
 def converted_op_code() -> XCOREOpCodes:
     return XCOREOpCodes.XC_bconv2d_int8_DIDO
-
-
-#  ----------------------------------------------------------------------------
-#                                   TESTS
-#  ----------------------------------------------------------------------------
-
-# TODO: remove this when bug is fixed
-def test_output(compared_outputs, request):
-    name = request.node.name
-    for config_idx in (20, 21, 22):
-        config_str = f"[CONFIGS[{config_idx}]]"
-        if name.endswith(config_str):
-            request.applymarker(pytest.mark.xfail(run=False))
-    _test_output(compared_outputs, request)
 
 
 if __name__ == "__main__":

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO.py
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO.py
@@ -12,7 +12,7 @@ from .test_bconv2d_int8 import (  # pylint: disable=unused-import
 from . import (  # pylint: disable=unused-import
     test_reference_model_regression,
     test_converted_single_op_model,
-    test_output,
+    test_output as _test_output,
 )
 
 
@@ -48,6 +48,20 @@ def reference_op_code() -> ExternalOpCodes:
 @pytest.fixture  # type: ignore
 def converted_op_code() -> XCOREOpCodes:
     return XCOREOpCodes.XC_bconv2d_int8_DIDO
+
+
+#  ----------------------------------------------------------------------------
+#                                   TESTS
+#  ----------------------------------------------------------------------------
+
+# TODO: remove this when bug is fixed
+def test_output(compared_outputs, request):
+    name = request.node.name
+    for config_idx in (20, 21, 22):
+        config_str = f"[CONFIGS[{config_idx}]]"
+        if name.endswith(config_str):
+            request.applymarker(pytest.mark.xfail(run=False))
+    _test_output(compared_outputs, request)
 
 
 if __name__ == "__main__":

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO.yml
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO.yml
@@ -261,3 +261,42 @@ default:
     - 1
     - 2
     width: 11
+  20:
+    K_h: 6
+    K_w: 4
+    height: 12
+    input_channels: 256
+    output_channels: 16
+    output_range:
+    - 0
+    - 1
+    strides:
+    - 2
+    - 1
+    width: 8
+  21:
+    K_h: 6
+    K_w: 5
+    height: 10
+    input_channels: 512
+    output_channels: 16
+    output_range:
+    - 0
+    - 1
+    strides:
+    - 2
+    - 2
+    width: 6
+  22:
+    K_h: 3
+    K_w: 3
+    height: 12
+    input_channels: 512
+    output_channels: 16
+    output_range:
+    - 0
+    - 1
+    strides:
+    - 1
+    - 2
+    width: 11

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO_activation.py
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO_activation.py
@@ -13,21 +13,8 @@ from .test_bconv2d_int8_DIDO import (  # pylint: disable=unused-import
 from . import (  # pylint: disable=unused-import
     test_reference_model_regression,
     test_converted_single_op_model,
-    test_output as _test_output,
+    test_output,
 )
-
-#  ----------------------------------------------------------------------------
-#                                   TESTS
-#  ----------------------------------------------------------------------------
-
-# TODO: remove this when bug is fixed
-def test_output(compared_outputs, request):
-    name = request.node.name
-    for config_idx in (9,):
-        config_str = f"[CONFIGS[{config_idx}]]"
-        if name.endswith(config_str):
-            request.applymarker(pytest.mark.xfail(run=False))
-    _test_output(compared_outputs, request)
 
 
 if __name__ == "__main__":

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO_activation.py
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO_activation.py
@@ -13,8 +13,21 @@ from .test_bconv2d_int8_DIDO import (  # pylint: disable=unused-import
 from . import (  # pylint: disable=unused-import
     test_reference_model_regression,
     test_converted_single_op_model,
-    test_output,
+    test_output as _test_output,
 )
+
+#  ----------------------------------------------------------------------------
+#                                   TESTS
+#  ----------------------------------------------------------------------------
+
+# TODO: remove this when bug is fixed
+def test_output(compared_outputs, request):
+    name = request.node.name
+    for config_idx in (9,):
+        config_str = f"[CONFIGS[{config_idx}]]"
+        if name.endswith(config_str):
+            request.applymarker(pytest.mark.xfail(run=False))
+    _test_output(compared_outputs, request)
 
 
 if __name__ == "__main__":

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO_activation.py
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO_activation.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2020, XMOS Ltd, All rights reserved
+
+import pytest
+
+from .test_bconv2d_int8_DIDO import (  # pylint: disable=unused-import
+    GENERATOR,
+    RUNNER,
+    bitpacked_outputs,
+    reference_op_code,
+    converted_op_code,
+)
+
+from . import (  # pylint: disable=unused-import
+    test_reference_model_regression,
+    test_converted_single_op_model,
+    test_output,
+)
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO_activation.yml
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO_activation.yml
@@ -1,0 +1,283 @@
+# Copyright (c) 2020, XMOS Ltd, All rights reserved
+# RANDOMLY GENERATED CONFIGS, MODIFY AT OWN RISK
+default:
+  0:
+    K_h: 3
+    K_w: 3
+    activation: relu6
+    height: 12
+    input_channels: 256
+    output_channels: 48
+    output_range:
+    - 0
+    - 1
+    strides:
+    - 2
+    - 1
+    width: 6
+  1:
+    K_h: 1
+    K_w: 5
+    activation: relu6
+    height: 10
+    input_channels: 512
+    output_channels: 16
+    output_range:
+    - 0
+    - 5
+    strides:
+    - 2
+    - 1
+    width: 11
+  2:
+    K_h: 1
+    K_w: 5
+    activation: relu
+    height: 12
+    input_channels: 512
+    output_channels: 16
+    output_range:
+    - -4
+    - 1
+    strides:
+    - 1
+    - 2
+    width: 6
+  3:
+    K_h: 2
+    K_w: 3
+    activation: relu
+    height: 10
+    input_channels: 512
+    output_channels: 16
+    output_range:
+    - 0
+    - 3
+    strides:
+    - 1
+    - 1
+    width: 11
+  4:
+    K_h: 6
+    K_w: 1
+    activation: relu6
+    height: 10
+    input_channels: 256
+    output_channels: 48
+    output_range:
+    - -2
+    - 5
+    strides:
+    - 2
+    - 2
+    width: 8
+  5:
+    K_h: 1
+    K_w: 3
+    activation: relu
+    height: 7
+    input_channels: 512
+    output_channels: 16
+    output_range:
+    - -4
+    - 5
+    strides:
+    - 1
+    - 1
+    width: 8
+  6:
+    K_h: 2
+    K_w: 5
+    activation: relu6
+    height: 7
+    input_channels: 256
+    output_channels: 16
+    output_range:
+    - 0
+    - 1
+    strides:
+    - 2
+    - 1
+    width: 6
+  7:
+    K_h: 2
+    K_w: 5
+    activation: relu6
+    height: 10
+    input_channels: 256
+    output_channels: 48
+    output_range:
+    - -2
+    - 5
+    strides:
+    - 2
+    - 2
+    width: 11
+  8:
+    K_h: 6
+    K_w: 5
+    activation: relu6
+    height: 12
+    input_channels: 256
+    output_channels: 48
+    output_range:
+    - -2
+    - 3
+    strides:
+    - 2
+    - 2
+    width: 8
+  9:
+    K_h: 6
+    K_w: 4
+    activation: relu6
+    height: 12
+    input_channels: 512
+    output_channels: 16
+    output_range:
+    - -2
+    - 1
+    strides:
+    - 2
+    - 1
+    width: 11
+  10:
+    K_h: 2
+    K_w: 3
+    activation: relu
+    height: 7
+    input_channels: 512
+    output_channels: 48
+    output_range:
+    - 0
+    - 3
+    strides:
+    - 2
+    - 2
+    width: 11
+  11:
+    K_h: 1
+    K_w: 1
+    activation: relu6
+    height: 12
+    input_channels: 256
+    output_channels: 16
+    output_range:
+    - -4
+    - 1
+    strides:
+    - 1
+    - 1
+    width: 6
+  12:
+    K_h: 3
+    K_w: 4
+    activation: relu6
+    height: 7
+    input_channels: 512
+    output_channels: 48
+    output_range:
+    - -4
+    - 5
+    strides:
+    - 1
+    - 1
+    width: 8
+  13:
+    K_h: 3
+    K_w: 1
+    activation: relu6
+    height: 10
+    input_channels: 512
+    output_channels: 48
+    output_range:
+    - -2
+    - 3
+    strides:
+    - 2
+    - 1
+    width: 8
+  14:
+    K_h: 1
+    K_w: 3
+    activation: relu
+    height: 12
+    input_channels: 512
+    output_channels: 48
+    output_range:
+    - -4
+    - 1
+    strides:
+    - 1
+    - 2
+    width: 6
+  15:
+    K_h: 3
+    K_w: 4
+    activation: relu
+    height: 7
+    input_channels: 256
+    output_channels: 16
+    output_range:
+    - -4
+    - 5
+    strides:
+    - 1
+    - 2
+    width: 11
+  16:
+    K_h: 6
+    K_w: 1
+    activation: relu
+    height: 10
+    input_channels: 256
+    output_channels: 16
+    output_range:
+    - 0
+    - 5
+    strides:
+    - 2
+    - 2
+    width: 8
+  17:
+    K_h: 6
+    K_w: 1
+    activation: relu
+    height: 12
+    input_channels: 256
+    output_channels: 48
+    output_range:
+    - -4
+    - 3
+    strides:
+    - 1
+    - 2
+    width: 6
+  18:
+    K_h: 2
+    K_w: 4
+    activation: relu
+    height: 10
+    input_channels: 256
+    output_channels: 48
+    output_range:
+    - 0
+    - 3
+    strides:
+    - 1
+    - 1
+    width: 8
+  19:
+    K_h: 3
+    K_w: 4
+    activation: relu
+    height: 7
+    input_channels: 512
+    output_channels: 16
+    output_range:
+    - -2
+    - 3
+    strides:
+    - 1
+    - 2
+    width: 6

--- a/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_activation.py
+++ b/test/model_generation/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_activation.py
@@ -13,21 +13,8 @@ from .test_bconv2d_int8 import (  # pylint: disable=unused-import
 from . import (  # pylint: disable=unused-import
     test_reference_model_regression,
     test_converted_single_op_model,
-    test_output as _test_output,
+    test_output,
 )
-
-#  ----------------------------------------------------------------------------
-#                                   TESTS
-#  ----------------------------------------------------------------------------
-
-# TODO: remove this when bug is fixed
-def test_output(compared_outputs, request):
-    name = request.node.name
-    for config_idx in (1, 2, 3, 4, 5, 7, 8, 9, 11, 13, 14, 15, 16, 17):
-        config_str = f"[CONFIGS[{config_idx}]]"
-        if name.endswith(config_str):
-            request.applymarker(pytest.mark.xfail(run=False))
-    _test_output(compared_outputs, request)
 
 
 if __name__ == "__main__":

--- a/tflite2xcore/tflite2xcore/tests/test_transformation_passes/test_lce_passes/test_LegalizeBconv2dInt8DeepInDeepOutPass.py
+++ b/tflite2xcore/tflite2xcore/tests/test_transformation_passes/test_lce_passes/test_LegalizeBconv2dInt8DeepInDeepOutPass.py
@@ -5,9 +5,9 @@ from tflite2xcore.transformation_passes import (
     LegalizeBconv2dInt8DeepInDeepOutPass,
     ReplaceBconv2DInt8DeepInDeepOutPass,
 )
+from tflite2xcore.xcore_schema import XCOREModel, XCOREOpCodes
 
-from .test_LegalizeBconv2dInt8Pass import test_mutate  # pylint: disable=unused-import
-
+from .test_LegalizeBconv2dInt8Pass import _test_mutate
 from .test_ReplaceBconv2DInt8DeepInDeepOutPass import (  # pylint: disable=unused-import
     model,
     new_opcode,
@@ -28,6 +28,23 @@ def replacement_pass() -> ReplaceBconv2DInt8DeepInDeepOutPass:
 @pytest.fixture()  # type: ignore
 def legalization_pass() -> LegalizeBconv2dInt8DeepInDeepOutPass:
     return LegalizeBconv2dInt8DeepInDeepOutPass()
+
+
+#  ----------------------------------------------------------------------------
+#                                   TESTS
+#  ----------------------------------------------------------------------------
+
+
+def test_mutate(
+    replacement_pass: ReplaceBconv2DInt8DeepInDeepOutPass,
+    legalization_pass: LegalizeBconv2dInt8DeepInDeepOutPass,
+    model: XCOREModel,
+    new_opcode: XCOREOpCodes,
+) -> None:
+    _test_mutate(replacement_pass, legalization_pass, model, new_opcode)
+
+    bconv2d_op = model.subgraphs[0].operators[0]
+    assert len(bconv2d_op.inputs) == 4
 
 
 if __name__ == "__main__":

--- a/tflite2xcore/tflite2xcore/tests/test_transformation_passes/test_lce_passes/test_LegalizeBconv2dInt8Pass.py
+++ b/tflite2xcore/tflite2xcore/tests/test_transformation_passes/test_lce_passes/test_LegalizeBconv2dInt8Pass.py
@@ -73,6 +73,7 @@ def test_mutate(
     # check custom options
     options = bconv2d_op.custom_options
     assert "illegal_params" not in options
+    assert "fused_activation_function" not in options
     assert options["K"][:3] == old_weights.shape[:3]
     assert options["K"][3] == old_weights.shape[3] * WORD_SIZE_BITS
 

--- a/tflite2xcore/tflite2xcore/tests/test_transformation_passes/test_lce_passes/test_ReplaceBconv2DInt8Pass.py
+++ b/tflite2xcore/tflite2xcore/tests/test_transformation_passes/test_lce_passes/test_ReplaceBconv2DInt8Pass.py
@@ -87,6 +87,8 @@ def test_mutate(
 
     new_op = operators[-1]
 
+    assert "fused_activation_function" in new_op.custom_options
+
     assert len(new_op.inputs) == 4
     new_op.inputs[1].type is TensorType.INT32
     new_op.inputs[2].type is TensorType.INT16

--- a/tflite2xcore/tflite2xcore/utils.py
+++ b/tflite2xcore/tflite2xcore/utils.py
@@ -7,6 +7,7 @@ import argparse
 import logging
 import numpy as np
 import tensorflow as tf
+from math import log2, ceil
 from functools import wraps
 from types import TracebackType
 from typing import (
@@ -235,6 +236,11 @@ def xor_popcount(a: np.ndarray, b: np.ndarray) -> int:
     return np.count_nonzero(unpack_bits(np.bitwise_xor(a, b)))  # type: ignore
 
 
+def clrsb(a: int, bitwidth: int = 32) -> int:
+    """ counts leading redundant sign bits """
+    return bitwidth - ceil(log2(abs(a))) - 1
+
+
 # -----------------------------------------------------------------------------
 #                          QUANTIZATION HELPERS
 # -----------------------------------------------------------------------------
@@ -334,7 +340,7 @@ def quantize_keras_model(
 
 def _calculate_valid_output_size(in_size: int, stride: int, k_dim: int) -> int:
     assert in_size >= k_dim
-    return int(np.ceil((in_size - k_dim + 1) / stride))
+    return ceil((in_size - k_dim + 1) / stride)
 
 
 def calculate_valid_output_size(
@@ -346,7 +352,7 @@ def calculate_valid_output_size(
 
 
 def _calculate_same_output_size(in_size: int, stride: int) -> int:
-    return int(np.ceil(in_size / stride))
+    return ceil(in_size / stride)
 
 
 def calculate_same_output_size(

--- a/tflite2xcore/tflite2xcore/xcore_schema/data_container.py
+++ b/tflite2xcore/tflite2xcore/xcore_schema/data_container.py
@@ -4,7 +4,7 @@ import logging
 import numpy as np
 from typing import TYPE_CHECKING, Iterable, Optional, Union, List, Any
 
-from . import _IRObject, _ModelDependent, TensorType
+from . import _ModelDependent, TensorType
 
 if TYPE_CHECKING:
     from .xcore_model import XCOREModel

--- a/tflite2xcore/tflite2xcore/xcore_schema/misc_enums.pyi
+++ b/tflite2xcore/tflite2xcore/xcore_schema/misc_enums.pyi
@@ -14,5 +14,8 @@ class ActivationFunctionType(IntEnum):
 
 class QuantizationDetails(IntEnum): ...
 class FullyConnectedOptionsWeightsFormat(IntEnum): ...
-class Padding(IntEnum): ...
+
+class Padding(IntEnum):
+    SAME: Padding
+    VALID: Padding
 

--- a/tflite2xcore/tflite2xcore/xcore_schema/misc_enums.pyi
+++ b/tflite2xcore/tflite2xcore/xcore_schema/misc_enums.pyi
@@ -4,7 +4,14 @@ from enum import IntEnum
 
 # TODO: consider adding fields to this enums for IDE support
 
-class ActivationFunctionType(IntEnum): ...
+class ActivationFunctionType(IntEnum):
+    NONE: ActivationFunctionType
+    RELU: ActivationFunctionType
+    RELU_N1_TO_1: ActivationFunctionType
+    RELU6: ActivationFunctionType
+    TANH: ActivationFunctionType
+    SIGN_BIT: ActivationFunctionType
+
 class QuantizationDetails(IntEnum): ...
 class FullyConnectedOptionsWeightsFormat(IntEnum): ...
 class Padding(IntEnum): ...

--- a/tflite2xcore/tflite2xcore/xcore_schema/xcore_model.py
+++ b/tflite2xcore/tflite2xcore/xcore_schema/xcore_model.py
@@ -13,7 +13,6 @@ from typing import (
     Counter,
     TypeVar,
     Type,
-    Generic,
     overload,
     cast,
     MutableSequence,


### PR DESCRIPTION
This PR enables the conversion and inference of Larq bconv2d ops with int8 output and arbitrary fused activations. To achieve this, this PR:
- Changes the quantization parameter calculation and input kernel boggling logic in the bconv2d-related xformer passes.
- Updates the `lib_nn` submodule due to the relevant kernel changes delivered in https://github.com/xmos/lib_nn/pull/20.
- Updates the `tensorflow` submodule due to the relevant kernel changes delivered in https://github.com/xmos/tensorflow/pull/42.
- Implements necessary changes in the xformer unit tests, and the integration tests.
- Cleans up some unused imports and introduces type hints for some commonly used xformer IR Enums.