### PR TITLE
Feature/bconv2d parallelization tests

### DIFF
--- a/test/generate.ipynb
+++ b/test/generate.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,20 +101,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "47"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions, N=100)\n",
     "len(configs)"
@@ -122,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,20 +136,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "21"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions, N=50)\n",
     "len(configs)"
@@ -168,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,20 +210,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions, N=70)\n",
     "len(configs)"
@@ -253,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,20 +264,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "44"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions, N=55)\n",
     "len(configs)"
@@ -318,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +290,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,20 +328,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "52"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions, N=150)\n",
     "len(configs)"
@@ -393,7 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -409,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -431,7 +376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -457,20 +402,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "23"
-      ]
-     },
-     "execution_count": 96,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions, N=150)\n",
     "len(configs)"
@@ -478,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -494,7 +428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -512,7 +446,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -526,20 +460,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "40"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions, N=70)\n",
     "len(configs)"
@@ -547,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,7 +486,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -584,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -603,20 +526,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 91,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions, N=70)\n",
     "len(configs)"
@@ -624,7 +536,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -640,7 +552,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -658,7 +570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -670,20 +582,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "40"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions, N=62)\n",
     "len(configs)"
@@ -691,7 +592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -707,20 +608,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "40"
-      ]
-     },
-     "execution_count": 52,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions, N=62)\n",
     "len(configs)"
@@ -728,7 +618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -744,7 +634,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -758,7 +648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -770,20 +660,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "40"
-      ]
-     },
-     "execution_count": 64,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions, N=55)\n",
     "len(configs)"
@@ -791,7 +670,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -807,7 +686,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -820,20 +699,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "test_relu.yml 40\n",
-      "test_relu6.yml 40\n",
-      "test_sigmoid.yml 40\n",
-      "test_tanh.yml 40\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for file in [\"test_relu.yml\", \"test_relu6.yml\", \"test_sigmoid.yml\", \"test_tanh.yml\"]:\n",
     "    configs = make_configs(params, conditions=lambda _: True, N=40)\n",
@@ -850,7 +718,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -865,20 +733,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "40"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions=lambda _: True, N=40)\n",
     "len(configs)"
@@ -886,7 +743,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -902,7 +759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -917,20 +774,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
     "len(configs)"
@@ -938,7 +784,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -954,7 +800,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -968,20 +814,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
     "len(configs)"
@@ -989,7 +824,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1005,7 +840,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1017,26 +852,15 @@
     "    input_channels=[256,512],\n",
     "    output_channels=[32, 64],\n",
     "    strides=[(1,1), (1,2), (2,1), (2,2)],\n",
-    "#     num_threads=[1,2,5],\n",
+    "    num_threads=[1,2,5],\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 29,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
     "len(configs)"
@@ -1044,7 +868,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1060,7 +884,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1073,26 +897,15 @@
     "    output_channels=[32, 64],\n",
     "    padding=[\"same\"],\n",
     "    strides=[(1,1), (1,2), (2,1), (2,2)],\n",
-    "#     num_threads=[1,2,5],\n",
+    "    num_threads=[1,2,5],\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 39,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
     "len(configs)"
@@ -1100,7 +913,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1116,7 +929,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1128,26 +941,15 @@
     "    input_channels=[32, 128],\n",
     "    output_channels=[32, 64],\n",
     "    strides=[(1,1), (1,2), (2,1), (2,2)],\n",
-    "#     num_threads=[1,2,5],\n",
+    "    num_threads=[1,2,5],\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
     "len(configs)"
@@ -1155,7 +957,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1171,7 +973,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1184,26 +986,15 @@
     "    output_channels=[32, 64],\n",
     "    padding=[\"same\"],\n",
     "    strides=[(1,1), (1,2), (2,1), (2,2)],\n",
-    "#     num_threads=[1,2,5],\n",
+    "    num_threads=[1,2,5],\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
     "len(configs)"
@@ -1211,7 +1002,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1227,7 +1018,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1244,7 +1035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1254,20 +1045,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
     "len(configs)"
@@ -1275,7 +1055,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1291,7 +1071,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1303,27 +1083,16 @@
     "    input_channels=[256,512],\n",
     "    output_channels=[16, 48],\n",
     "    strides=[(1,1), (1,2), (2,1), (2,2)],\n",
-    "    output_range = [(range_min, range_max) for range_min in range(-4, 1, 2) for range_max in range(1, 6, 2)]\n",
-    "#     num_threads=[1,2,5],\n",
+    "    output_range = [(range_min, range_max) for range_min in range(-4, 1, 2) for range_max in range(1, 6, 2)],\n",
+    "    num_threads=[1,2,5],\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
     "len(configs)"
@@ -1331,7 +1100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1347,7 +1116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1359,29 +1128,18 @@
     "    input_channels=[32, 128, 256+64],\n",
     "    output_channels=[4, 28, 32],\n",
     "    strides=[(1,1), (1,2), (2,1), (2,2)],\n",
-    "    output_range = [(range_min, range_max) for range_min in range(-4, 1, 2) for range_max in range(1, 6, 2)]\n",
-    "#     num_threads=[1,2,5],\n",
+    "    output_range = [(range_min, range_max) for range_min in range(-4, 1, 2) for range_max in range(1, 6, 2)],\n",
+    "    num_threads=[1,2,5],\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
     "len(configs)"
@@ -1389,7 +1147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1405,7 +1163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1425,20 +1183,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
     "len(configs)"
@@ -1446,7 +1193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1462,7 +1209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1475,27 +1222,16 @@
     "    output_channels=[4, 28, 32],\n",
     "    strides=[(1,1), (1,2), (2,1), (2,2)],\n",
     "    padding=[\"same\"],\n",
-    "    output_range = [(range_min, range_max) for range_min in range(-4, 1, 2) for range_max in range(1, 6, 2)]\n",
-    "#     num_threads=[1,2,5],\n",
+    "    output_range = [(range_min, range_max) for range_min in range(-4, 1, 2) for range_max in range(1, 6, 2)],\n",
+    "    num_threads=[1,2,5],\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
     "len(configs)"
@@ -1503,7 +1239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1519,7 +1255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1533,26 +1269,15 @@
     "    strides=[(1,1), (1,2), (2,1), (2,2)],\n",
     "    output_range = [(range_min, range_max) for range_min in range(-4, 1, 2) for range_max in range(1, 6, 2)],\n",
     "    activation = [\"relu\", \"relu6\"],\n",
-    "#     num_threads=[1,2,5],\n",
+    "    num_threads=[1,2,5],\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
     "len(configs)"
@@ -1560,7 +1285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1576,7 +1301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1590,26 +1315,15 @@
     "    strides=[(1,1), (1,2), (2,1), (2,2)],\n",
     "    output_range = [(range_min, range_max) for range_min in range(-4, 1, 2) for range_max in range(1, 6, 2)],\n",
     "    activation = [\"relu\", \"relu6\"],\n",
-    "#     num_threads=[1,2,5],\n",
+    "    num_threads=[1,2,5],\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "20"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "configs = make_configs(params, conditions=lambda _: True, N=20)\n",
     "len(configs)"
@@ -1617,7 +1331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/test/integration_test/test_single_op_models/test_binarized/padded/test_bconv2d_bin_DI_padded.yml
+++ b/test/integration_test/test_single_op_models/test_binarized/padded/test_bconv2d_bin_DI_padded.yml
@@ -3,86 +3,94 @@
 default:
   0:
     K_h: 2
-    K_w: 4
+    K_w: 3
     height: 10
-    input_channels: 512
-    output_channels: 64
-    padding: same
-    strides:
-    - 1
-    - 1
-    width: 8
-  1:
-    K_h: 3
-    K_w: 4
-    height: 7
     input_channels: 256
+    num_threads: 2
     output_channels: 32
     padding: same
     strides:
     - 1
     - 1
     width: 11
-  2:
+  1:
     K_h: 3
     K_w: 3
-    height: 7
-    input_channels: 512
-    output_channels: 64
-    padding: same
-    strides:
-    - 2
-    - 1
-    width: 8
-  3:
-    K_h: 2
-    K_w: 4
     height: 10
     input_channels: 512
+    num_threads: 2
     output_channels: 32
     padding: same
     strides:
-    - 2
+    - 1
     - 2
     width: 6
-  4:
+  2:
     K_h: 6
-    K_w: 5
+    K_w: 3
     height: 10
     input_channels: 256
+    num_threads: 1
+    output_channels: 64
+    padding: same
+    strides:
+    - 2
+    - 2
+    width: 8
+  3:
+    K_h: 3
+    K_w: 4
+    height: 7
+    input_channels: 256
+    num_threads: 1
     output_channels: 64
     padding: same
     strides:
     - 1
-    - 2
+    - 1
+    width: 8
+  4:
+    K_h: 2
+    K_w: 3
+    height: 10
+    input_channels: 256
+    num_threads: 5
+    output_channels: 64
+    padding: same
+    strides:
+    - 1
+    - 1
     width: 6
   5:
     K_h: 2
-    K_w: 4
-    height: 12
-    input_channels: 256
-    output_channels: 32
+    K_w: 3
+    height: 7
+    input_channels: 512
+    num_threads: 5
+    output_channels: 64
     padding: same
     strides:
     - 1
-    - 1
+    - 2
     width: 8
   6:
     K_h: 3
     K_w: 4
-    height: 12
+    height: 7
     input_channels: 256
+    num_threads: 2
     output_channels: 64
     padding: same
     strides:
-    - 1
     - 2
-    width: 11
+    - 1
+    width: 6
   7:
     K_h: 6
-    K_w: 3
-    height: 7
+    K_w: 5
+    height: 12
     input_channels: 256
+    num_threads: 1
     output_channels: 64
     padding: same
     strides:
@@ -90,134 +98,146 @@ default:
     - 1
     width: 8
   8:
-    K_h: 2
-    K_w: 5
-    height: 7
+    K_h: 6
+    K_w: 3
+    height: 12
     input_channels: 512
+    num_threads: 2
     output_channels: 32
     padding: same
     strides:
+    - 1
     - 2
-    - 2
-    width: 8
+    width: 6
   9:
     K_h: 6
     K_w: 5
     height: 12
     input_channels: 512
+    num_threads: 5
     output_channels: 32
     padding: same
     strides:
     - 2
-    - 1
-    width: 11
+    - 2
+    width: 8
   10:
     K_h: 3
     K_w: 4
+    height: 10
+    input_channels: 256
+    num_threads: 1
+    output_channels: 64
+    padding: same
+    strides:
+    - 1
+    - 2
+    width: 6
+  11:
+    K_h: 6
+    K_w: 5
+    height: 12
+    input_channels: 256
+    num_threads: 1
+    output_channels: 32
+    padding: same
+    strides:
+    - 2
+    - 1
+    width: 11
+  12:
+    K_h: 2
+    K_w: 4
     height: 7
     input_channels: 512
-    output_channels: 64
+    num_threads: 5
+    output_channels: 32
     padding: same
     strides:
     - 2
     - 2
     width: 11
-  11:
-    K_h: 2
-    K_w: 4
-    height: 10
-    input_channels: 256
-    output_channels: 64
-    padding: same
-    strides:
-    - 2
-    - 2
-    width: 6
-  12:
+  13:
     K_h: 3
     K_w: 5
     height: 10
     input_channels: 256
+    num_threads: 2
+    output_channels: 32
+    padding: same
+    strides:
+    - 1
+    - 2
+    width: 11
+  14:
+    K_h: 2
+    K_w: 4
+    height: 10
+    input_channels: 512
+    num_threads: 2
     output_channels: 32
     padding: same
     strides:
     - 2
     - 1
-    width: 8
-  13:
-    K_h: 6
-    K_w: 3
-    height: 12
-    input_channels: 512
-    output_channels: 64
-    padding: same
-    strides:
-    - 1
-    - 1
     width: 11
-  14:
+  15:
     K_h: 6
     K_w: 4
     height: 12
-    input_channels: 256
-    output_channels: 32
+    input_channels: 512
+    num_threads: 5
+    output_channels: 64
     padding: same
     strides:
     - 2
-    - 1
-    width: 6
-  15:
-    K_h: 3
-    K_w: 3
-    height: 12
-    input_channels: 512
-    output_channels: 32
-    padding: same
-    strides:
-    - 1
     - 1
     width: 11
   16:
-    K_h: 2
-    K_w: 3
-    height: 7
-    input_channels: 512
-    output_channels: 64
-    padding: same
-    strides:
-    - 1
-    - 2
-    width: 8
-  17:
     K_h: 6
     K_w: 5
     height: 7
     input_channels: 512
+    num_threads: 2
     output_channels: 32
     padding: same
     strides:
     - 2
     - 2
     width: 8
-  18:
+  17:
     K_h: 3
     K_w: 5
     height: 12
     input_channels: 256
+    num_threads: 5
     output_channels: 64
     padding: same
     strides:
     - 1
+    - 1
+    width: 11
+  18:
+    K_h: 2
+    K_w: 5
+    height: 7
+    input_channels: 512
+    num_threads: 2
+    output_channels: 64
+    padding: same
+    strides:
+    - 2
     - 2
     width: 6
   19:
     K_h: 2
-    K_w: 3
-    height: 10
-    input_channels: 256
+    K_w: 4
+    height: 12
+    input_channels: 512
+    num_threads: 1
     output_channels: 32
     padding: same
     strides:
     - 1
-    - 2
+    - 1
     width: 6

--- a/test/integration_test/test_single_op_models/test_binarized/padded/test_bconv2d_bin_padded.yml
+++ b/test/integration_test/test_single_op_models/test_binarized/padded/test_bconv2d_bin_padded.yml
@@ -2,222 +2,242 @@
 # RANDOMLY GENERATED CONFIGS, MODIFY AT OWN RISK
 default:
   0:
-    K_h: 1
-    K_w: 3
-    height: 7
-    input_channels: 128
-    output_channels: 64
-    padding: same
-    strides:
-    - 2
-    - 1
-    width: 8
-  1:
-    K_h: 6
-    K_w: 3
-    height: 7
-    input_channels: 32
-    output_channels: 32
-    padding: same
-    strides:
-    - 2
-    - 2
-    width: 11
-  2:
     K_h: 2
     K_w: 4
     height: 12
     input_channels: 32
+    num_threads: 2
     output_channels: 32
     padding: same
     strides:
+    - 2
+    - 2
+    width: 6
+  1:
+    K_h: 6
+    K_w: 1
+    height: 7
+    input_channels: 32
+    num_threads: 1
+    output_channels: 64
+    padding: same
+    strides:
     - 1
+    - 2
+    width: 8
+  2:
+    K_h: 3
+    K_w: 1
+    height: 12
+    input_channels: 128
+    num_threads: 2
+    output_channels: 64
+    padding: same
+    strides:
+    - 2
     - 1
     width: 11
   3:
-    K_h: 3
+    K_h: 6
     K_w: 3
     height: 10
     input_channels: 32
-    output_channels: 64
-    padding: same
-    strides:
-    - 1
-    - 1
-    width: 6
-  4:
-    K_h: 3
-    K_w: 4
-    height: 12
-    input_channels: 128
-    output_channels: 64
-    padding: same
-    strides:
-    - 1
-    - 2
-    width: 11
-  5:
-    K_h: 2
-    K_w: 3
-    height: 10
-    input_channels: 128
+    num_threads: 5
     output_channels: 64
     padding: same
     strides:
     - 1
     - 1
     width: 8
-  6:
+  4:
+    K_h: 1
+    K_w: 3
+    height: 7
+    input_channels: 128
+    num_threads: 2
+    output_channels: 32
+    padding: same
+    strides:
+    - 2
+    - 2
+    width: 8
+  5:
     K_h: 1
     K_w: 5
     height: 7
     input_channels: 32
+    num_threads: 1
     output_channels: 32
     padding: same
     strides:
     - 2
-    - 2
-    width: 6
-  7:
-    K_h: 2
-    K_w: 4
-    height: 7
-    input_channels: 128
-    output_channels: 32
-    padding: same
-    strides:
     - 1
-    - 2
-    width: 6
-  8:
-    K_h: 6
+    width: 11
+  6:
+    K_h: 3
     K_w: 1
     height: 7
     input_channels: 128
+    num_threads: 2
+    output_channels: 64
+    padding: same
+    strides:
+    - 1
+    - 1
+    width: 11
+  7:
+    K_h: 1
+    K_w: 4
+    height: 12
+    input_channels: 128
+    num_threads: 1
+    output_channels: 32
+    padding: same
+    strides:
+    - 2
+    - 2
+    width: 8
+  8:
+    K_h: 2
+    K_w: 5
+    height: 12
+    input_channels: 32
+    num_threads: 2
+    output_channels: 32
+    padding: same
+    strides:
+    - 1
+    - 2
+    width: 6
+  9:
+    K_h: 6
+    K_w: 3
+    height: 10
+    input_channels: 32
+    num_threads: 5
+    output_channels: 64
+    padding: same
+    strides:
+    - 2
+    - 2
+    width: 6
+  10:
+    K_h: 2
+    K_w: 3
+    height: 10
+    input_channels: 128
+    num_threads: 5
+    output_channels: 32
+    padding: same
+    strides:
+    - 2
+    - 1
+    width: 11
+  11:
+    K_h: 6
+    K_w: 4
+    height: 10
+    input_channels: 128
+    num_threads: 2
+    output_channels: 64
+    padding: same
+    strides:
+    - 2
+    - 2
+    width: 8
+  12:
+    K_h: 2
+    K_w: 3
+    height: 7
+    input_channels: 32
+    num_threads: 5
     output_channels: 32
     padding: same
     strides:
     - 1
     - 1
     width: 8
-  9:
-    K_h: 6
-    K_w: 5
-    height: 12
-    input_channels: 32
-    output_channels: 32
-    padding: same
-    strides:
-    - 1
-    - 1
-    width: 11
-  10:
-    K_h: 6
-    K_w: 4
-    height: 10
-    input_channels: 32
-    output_channels: 64
-    padding: same
-    strides:
-    - 1
-    - 2
-    width: 6
-  11:
-    K_h: 6
-    K_w: 5
-    height: 10
-    input_channels: 32
-    output_channels: 32
-    padding: same
-    strides:
-    - 1
-    - 2
-    width: 6
-  12:
-    K_h: 1
-    K_w: 5
-    height: 12
-    input_channels: 32
-    output_channels: 32
-    padding: same
-    strides:
-    - 2
-    - 1
-    width: 11
   13:
-    K_h: 3
-    K_w: 3
-    height: 12
+    K_h: 1
+    K_w: 4
+    height: 7
     input_channels: 128
+    num_threads: 5
     output_channels: 64
     padding: same
     strides:
-    - 2
     - 1
-    width: 11
+    - 1
+    width: 6
   14:
     K_h: 3
     K_w: 1
-    height: 10
-    input_channels: 128
+    height: 12
+    input_channels: 32
+    num_threads: 5
     output_channels: 64
     padding: same
     strides:
-    - 2
     - 1
-    width: 8
+    - 2
+    width: 6
   15:
-    K_h: 1
-    K_w: 1
-    height: 10
-    input_channels: 32
-    output_channels: 64
-    padding: same
-    strides:
-    - 2
-    - 2
-    width: 8
-  16:
-    K_h: 2
+    K_h: 6
     K_w: 4
-    height: 7
-    input_channels: 128
-    output_channels: 64
-    padding: same
-    strides:
-    - 2
-    - 2
-    width: 8
-  17:
-    K_h: 3
-    K_w: 1
     height: 10
-    input_channels: 32
+    input_channels: 128
+    num_threads: 1
     output_channels: 32
     padding: same
     strides:
-    - 2
     - 1
-    width: 6
-  18:
-    K_h: 2
+    - 1
+    width: 11
+  16:
+    K_h: 3
     K_w: 5
     height: 10
     input_channels: 128
+    num_threads: 1
+    output_channels: 64
+    padding: same
+    strides:
+    - 1
+    - 2
+    width: 8
+  17:
+    K_h: 1
+    K_w: 5
+    height: 10
+    input_channels: 32
+    num_threads: 5
     output_channels: 64
     padding: same
     strides:
     - 2
-    - 2
-    width: 8
-  19:
-    K_h: 1
+    - 1
+    width: 11
+  18:
+    K_h: 2
     K_w: 1
-    height: 12
+    height: 10
     input_channels: 128
+    num_threads: 1
     output_channels: 32
     padding: same
     strides:
     - 1
     - 2
     width: 11
+  19:
+    K_h: 3
+    K_w: 5
+    height: 12
+    input_channels: 32
+    num_threads: 1
+    output_channels: 32
+    padding: same
+    strides:
+    - 2
+    - 1
+    width: 6

--- a/test/integration_test/test_single_op_models/test_binarized/padded/test_bconv2d_int8_padded.yml
+++ b/test/integration_test/test_single_op_models/test_binarized/padded/test_bconv2d_int8_padded.yml
@@ -2,25 +2,87 @@
 # RANDOMLY GENERATED CONFIGS, MODIFY AT OWN RISK
 default:
   0:
-    K_h: 1
-    K_w: 1
-    height: 7
-    input_channels: 320
+    K_h: 2
+    K_w: 4
+    height: 10
+    input_channels: 32
+    num_threads: 5
+    output_channels: 4
+    output_range:
+    - -4
+    - 1
+    padding: same
+    strides:
+    - 2
+    - 1
+    width: 8
+  1:
+    K_h: 3
+    K_w: 5
+    height: 10
+    input_channels: 128
+    num_threads: 5
     output_channels: 32
     output_range:
-    - 0
-    - 1
+    - -4
+    - 5
+    padding: same
+    strides:
+    - 2
+    - 2
+    width: 6
+  2:
+    K_h: 1
+    K_w: 5
+    height: 12
+    input_channels: 320
+    num_threads: 1
+    output_channels: 4
+    output_range:
+    - -2
+    - 3
     padding: same
     strides:
     - 1
     - 2
     width: 8
-  1:
+  3:
+    K_h: 3
+    K_w: 4
+    height: 7
+    input_channels: 128
+    num_threads: 5
+    output_channels: 32
+    output_range:
+    - 0
+    - 5
+    padding: same
+    strides:
+    - 2
+    - 2
+    width: 6
+  4:
     K_h: 2
     K_w: 3
+    height: 10
+    input_channels: 320
+    num_threads: 1
+    output_channels: 28
+    output_range:
+    - -2
+    - 5
+    padding: same
+    strides:
+    - 1
+    - 2
+    width: 8
+  5:
+    K_h: 2
+    K_w: 1
     height: 7
     input_channels: 32
-    output_channels: 28
+    num_threads: 1
+    output_channels: 4
     output_range:
     - -4
     - 1
@@ -29,179 +91,102 @@ default:
     - 1
     - 2
     width: 6
-  2:
-    K_h: 1
-    K_w: 1
-    height: 12
-    input_channels: 320
-    output_channels: 32
-    output_range:
-    - -2
-    - 5
-    padding: same
-    strides:
-    - 1
-    - 2
-    width: 6
-  3:
-    K_h: 2
-    K_w: 4
-    height: 10
-    input_channels: 320
-    output_channels: 4
-    output_range:
-    - 0
-    - 3
-    padding: same
-    strides:
-    - 2
-    - 1
-    width: 8
-  4:
+  6:
     K_h: 3
     K_w: 3
-    height: 12
-    input_channels: 32
-    output_channels: 4
-    output_range:
-    - 0
-    - 1
-    padding: same
-    strides:
-    - 1
-    - 1
-    width: 11
-  5:
-    K_h: 6
-    K_w: 1
     height: 10
     input_channels: 128
-    output_channels: 28
-    output_range:
-    - 0
-    - 5
-    padding: same
-    strides:
-    - 2
-    - 2
-    width: 11
-  6:
-    K_h: 1
-    K_w: 1
-    height: 7
-    input_channels: 32
+    num_threads: 1
     output_channels: 4
     output_range:
-    - -2
-    - 1
+    - -4
+    - 3
     padding: same
     strides:
     - 1
     - 1
     width: 11
   7:
-    K_h: 3
+    K_h: 1
     K_w: 3
     height: 12
-    input_channels: 32
-    output_channels: 4
-    output_range:
-    - -4
-    - 5
-    padding: same
-    strides:
-    - 2
-    - 1
-    width: 8
-  8:
-    K_h: 6
-    K_w: 1
-    height: 12
-    input_channels: 32
-    output_channels: 32
-    output_range:
-    - -4
-    - 3
-    padding: same
-    strides:
-    - 1
-    - 1
-    width: 8
-  9:
-    K_h: 1
-    K_w: 4
-    height: 10
-    input_channels: 128
+    input_channels: 320
+    num_threads: 5
     output_channels: 4
     output_range:
     - -2
-    - 3
+    - 1
+    padding: same
+    strides:
+    - 2
+    - 2
+    width: 6
+  8:
+    K_h: 1
+    K_w: 5
+    height: 7
+    input_channels: 128
+    num_threads: 2
+    output_channels: 28
+    output_range:
+    - 0
+    - 1
+    padding: same
+    strides:
+    - 1
+    - 1
+    width: 11
+  9:
+    K_h: 3
+    K_w: 1
+    height: 12
+    input_channels: 320
+    num_threads: 1
+    output_channels: 4
+    output_range:
+    - -2
+    - 5
     padding: same
     strides:
     - 1
     - 2
-    width: 6
+    width: 11
   10:
     K_h: 6
     K_w: 5
     height: 10
     input_channels: 320
-    output_channels: 4
+    num_threads: 2
+    output_channels: 32
     output_range:
-    - -2
-    - 5
+    - 0
+    - 1
     padding: same
     strides:
     - 2
     - 1
-    width: 8
+    width: 11
   11:
-    K_h: 2
-    K_w: 3
+    K_h: 1
+    K_w: 5
     height: 12
     input_channels: 32
+    num_threads: 2
     output_channels: 32
     output_range:
     - -4
-    - 3
+    - 1
     padding: same
     strides:
-    - 2
-    - 2
+    - 1
+    - 1
     width: 11
   12:
     K_h: 6
-    K_w: 3
-    height: 12
-    input_channels: 320
-    output_channels: 28
-    output_range:
-    - -4
-    - 1
-    padding: same
-    strides:
-    - 2
-    - 1
-    width: 8
-  13:
-    K_h: 6
-    K_w: 5
+    K_w: 1
     height: 7
-    input_channels: 320
-    output_channels: 32
-    output_range:
-    - -2
-    - 1
-    padding: same
-    strides:
-    - 1
-    - 1
-    width: 8
-  14:
-    K_h: 1
-    K_w: 5
-    height: 10
-    input_channels: 128
+    input_channels: 32
+    num_threads: 5
     output_channels: 28
     output_range:
     - -4
@@ -209,41 +194,104 @@ default:
     padding: same
     strides:
     - 2
+    - 1
+    width: 11
+  13:
+    K_h: 6
+    K_w: 1
+    height: 7
+    input_channels: 128
+    num_threads: 5
+    output_channels: 28
+    output_range:
+    - -2
+    - 1
+    padding: same
+    strides:
     - 2
-    width: 6
+    - 1
+    width: 8
+  14:
+    K_h: 6
+    K_w: 3
+    height: 10
+    input_channels: 128
+    num_threads: 2
+    output_channels: 28
+    output_range:
+    - 0
+    - 3
+    padding: same
+    strides:
+    - 1
+    - 2
+    width: 8
   15:
     K_h: 2
     K_w: 4
     height: 10
-    input_channels: 320
-    output_channels: 32
-    output_range:
-    - 0
-    - 1
-    padding: same
-    strides:
-    - 2
-    - 1
-    width: 6
-  16:
-    K_h: 3
-    K_w: 5
-    height: 10
-    input_channels: 128
+    input_channels: 32
+    num_threads: 2
     output_channels: 28
     output_range:
     - -2
     - 3
     padding: same
     strides:
+    - 1
+    - 1
+    width: 8
+  16:
+    K_h: 3
+    K_w: 4
+    height: 12
+    input_channels: 32
+    num_threads: 5
+    output_channels: 4
+    output_range:
+    - 0
+    - 3
+    padding: same
+    strides:
+    - 2
+    - 2
+    width: 6
+  17:
+    K_h: 2
+    K_w: 4
+    height: 7
+    input_channels: 32
+    num_threads: 1
+    output_channels: 32
+    output_range:
+    - 0
+    - 3
+    padding: same
+    strides:
+    - 1
+    - 1
+    width: 8
+  18:
+    K_h: 1
+    K_w: 3
+    height: 12
+    input_channels: 320
+    num_threads: 1
+    output_channels: 28
+    output_range:
+    - -2
+    - 1
+    padding: same
+    strides:
     - 2
     - 2
     width: 11
-  17:
-    K_h: 2
-    K_w: 5
-    height: 7
+  19:
+    K_h: 6
+    K_w: 1
+    height: 12
     input_channels: 128
+    num_threads: 2
     output_channels: 32
     output_range:
     - 0
@@ -251,33 +299,5 @@ default:
     padding: same
     strides:
     - 2
-    - 2
-    width: 6
-  18:
-    K_h: 3
-    K_w: 4
-    height: 7
-    input_channels: 32
-    output_channels: 28
-    output_range:
-    - 0
-    - 5
-    padding: same
-    strides:
-    - 1
     - 1
     width: 6
-  19:
-    K_h: 32
-    K_w: 1
-    height: 32
-    input_channels: 256
-    output_channels: 4
-    output_range:
-    - -2
-    - 1
-    padding: valid
-    strides:
-    - 1
-    - 1
-    width: 1

--- a/test/integration_test/test_single_op_models/test_binarized/test_bconv2d_bin.yml
+++ b/test/integration_test/test_single_op_models/test_binarized/test_bconv2d_bin.yml
@@ -3,201 +3,221 @@
 default:
   0:
     K_h: 3
-    K_w: 1
-    height: 7
-    input_channels: 32
-    output_channels: 64
-    strides:
-    - 1
-    - 1
-    width: 6
-  1:
-    K_h: 3
     K_w: 3
-    height: 10
-    input_channels: 128
-    output_channels: 32
-    strides:
-    - 1
-    - 1
-    width: 6
-  2:
-    K_h: 6
-    K_w: 1
     height: 12
-    input_channels: 32
-    output_channels: 64
-    strides:
-    - 1
-    - 1
-    width: 8
-  3:
-    K_h: 6
-    K_w: 1
-    height: 10
     input_channels: 128
-    output_channels: 64
-    strides:
-    - 2
-    - 2
-    width: 8
-  4:
-    K_h: 6
-    K_w: 4
-    height: 10
-    input_channels: 32
-    output_channels: 64
-    strides:
-    - 2
-    - 1
-    width: 6
-  5:
-    K_h: 3
-    K_w: 3
-    height: 7
-    input_channels: 128
-    output_channels: 64
-    strides:
-    - 1
-    - 1
-    width: 6
-  6:
-    K_h: 1
-    K_w: 3
-    height: 7
-    input_channels: 128
-    output_channels: 64
-    strides:
-    - 2
-    - 2
-    width: 8
-  7:
-    K_h: 2
-    K_w: 5
-    height: 10
-    input_channels: 32
+    num_threads: 2
     output_channels: 32
     strides:
     - 2
     - 1
     width: 11
-  8:
+  1:
     K_h: 3
-    K_w: 5
-    height: 12
-    input_channels: 32
-    output_channels: 32
-    strides:
-    - 1
-    - 2
-    width: 8
-  9:
-    K_h: 2
-    K_w: 4
+    K_w: 3
     height: 10
-    input_channels: 128
-    output_channels: 32
+    input_channels: 32
+    num_threads: 2
+    output_channels: 64
     strides:
     - 2
     - 1
     width: 8
-  10:
-    K_h: 2
+  2:
+    K_h: 6
     K_w: 1
-    height: 12
+    height: 7
     input_channels: 128
-    output_channels: 64
+    num_threads: 5
+    output_channels: 32
     strides:
     - 2
     - 2
     width: 6
-  11:
+  3:
+    K_h: 2
+    K_w: 4
+    height: 10
+    input_channels: 128
+    num_threads: 2
+    output_channels: 32
+    strides:
+    - 1
+    - 1
+    width: 6
+  4:
+    K_h: 1
+    K_w: 1
+    height: 12
+    input_channels: 32
+    num_threads: 1
+    output_channels: 64
+    strides:
+    - 1
+    - 2
+    width: 11
+  5:
     K_h: 6
     K_w: 5
     height: 7
     input_channels: 128
+    num_threads: 1
     output_channels: 32
+    strides:
+    - 1
+    - 2
+    width: 11
+  6:
+    K_h: 6
+    K_w: 4
+    height: 10
+    input_channels: 32
+    num_threads: 2
+    output_channels: 32
+    strides:
+    - 1
+    - 1
+    width: 8
+  7:
+    K_h: 6
+    K_w: 5
+    height: 7
+    input_channels: 32
+    num_threads: 5
+    output_channels: 64
+    strides:
+    - 1
+    - 2
+    width: 8
+  8:
+    K_h: 2
+    K_w: 5
+    height: 12
+    input_channels: 32
+    num_threads: 5
+    output_channels: 64
+    strides:
+    - 2
+    - 1
+    width: 6
+  9:
+    K_h: 6
+    K_w: 5
+    height: 7
+    input_channels: 128
+    num_threads: 2
+    output_channels: 32
+    strides:
+    - 1
+    - 1
+    width: 8
+  10:
+    K_h: 1
+    K_w: 1
+    height: 10
+    input_channels: 128
+    num_threads: 1
+    output_channels: 64
     strides:
     - 2
     - 2
-    width: 8
-  12:
-    K_h: 2
-    K_w: 1
-    height: 12
+    width: 11
+  11:
+    K_h: 1
+    K_w: 5
+    height: 10
     input_channels: 128
-    output_channels: 32
+    num_threads: 1
+    output_channels: 64
+    strides:
+    - 1
+    - 1
+    width: 11
+  12:
+    K_h: 3
+    K_w: 1
+    height: 10
+    input_channels: 32
+    num_threads: 1
+    output_channels: 64
     strides:
     - 1
     - 2
     width: 6
   13:
-    K_h: 1
+    K_h: 2
     K_w: 3
-    height: 7
-    input_channels: 32
-    output_channels: 64
+    height: 12
+    input_channels: 128
+    num_threads: 2
+    output_channels: 32
     strides:
     - 2
     - 2
-    width: 11
+    width: 6
   14:
-    K_h: 6
+    K_h: 3
     K_w: 4
     height: 12
     input_channels: 128
+    num_threads: 5
     output_channels: 64
     strides:
-    - 2
     - 1
+    - 2
     width: 11
   15:
-    K_h: 1
-    K_w: 5
+    K_h: 2
+    K_w: 3
     height: 12
     input_channels: 32
+    num_threads: 2
     output_channels: 32
     strides:
     - 2
     - 1
-    width: 11
+    width: 8
   16:
     K_h: 3
-    K_w: 4
-    height: 7
+    K_w: 1
+    height: 12
     input_channels: 32
-    output_channels: 64
+    num_threads: 2
+    output_channels: 32
     strides:
-    - 1
     - 2
+    - 1
     width: 11
   17:
     K_h: 1
-    K_w: 3
-    height: 10
-    input_channels: 32
-    output_channels: 32
-    strides:
-    - 1
-    - 1
-    width: 11
-  18:
-    K_h: 2
-    K_w: 5
-    height: 10
-    input_channels: 128
-    output_channels: 32
-    strides:
-    - 1
-    - 2
-    width: 8
-  19:
-    K_h: 1
     K_w: 4
     height: 7
     input_channels: 32
+    num_threads: 1
+    output_channels: 64
+    strides:
+    - 2
+    - 2
+    width: 8
+  18:
+    K_h: 1
+    K_w: 3
+    height: 10
+    input_channels: 32
+    num_threads: 5
     output_channels: 32
     strides:
     - 1
+    - 1
+    width: 6
+  19:
+    K_h: 2
+    K_w: 4
+    height: 7
+    input_channels: 128
+    num_threads: 5
+    output_channels: 64
+    strides:
+    - 2
     - 2
     width: 6

--- a/test/integration_test/test_single_op_models/test_binarized/test_bconv2d_bin_DI.yml
+++ b/test/integration_test/test_single_op_models/test_binarized/test_bconv2d_bin_DI.yml
@@ -3,39 +3,43 @@
 default:
   0:
     K_h: 6
-    K_w: 5
-    height: 7
-    input_channels: 512
+    K_w: 3
+    height: 10
+    input_channels: 256
+    num_threads: 5
     output_channels: 64
     strides:
-    - 2
     - 1
-    width: 11
+    - 1
+    width: 6
   1:
-    K_h: 3
-    K_w: 5
-    height: 7
-    input_channels: 512
+    K_h: 6
+    K_w: 3
+    height: 10
+    input_channels: 256
+    num_threads: 1
     output_channels: 32
     strides:
     - 1
-    - 2
+    - 1
     width: 6
   2:
-    K_h: 3
-    K_w: 4
-    height: 10
-    input_channels: 512
-    output_channels: 32
+    K_h: 6
+    K_w: 3
+    height: 12
+    input_channels: 256
+    num_threads: 1
+    output_channels: 64
     strides:
     - 1
-    - 1
+    - 2
     width: 6
   3:
     K_h: 1
-    K_w: 5
+    K_w: 4
     height: 10
-    input_channels: 256
+    input_channels: 512
+    num_threads: 2
     output_channels: 64
     strides:
     - 1
@@ -43,82 +47,90 @@ default:
     width: 11
   4:
     K_h: 2
-    K_w: 3
+    K_w: 1
     height: 12
     input_channels: 256
+    num_threads: 1
     output_channels: 32
     strides:
     - 1
-    - 1
+    - 2
     width: 8
   5:
-    K_h: 2
-    K_w: 3
+    K_h: 6
+    K_w: 1
     height: 7
-    input_channels: 512
-    output_channels: 32
+    input_channels: 256
+    num_threads: 5
+    output_channels: 64
     strides:
     - 2
     - 2
     width: 11
   6:
     K_h: 1
-    K_w: 1
-    height: 7
-    input_channels: 512
-    output_channels: 64
-    strides:
-    - 1
-    - 2
-    width: 11
-  7:
-    K_h: 6
-    K_w: 4
-    height: 12
-    input_channels: 256
-    output_channels: 64
-    strides:
-    - 1
-    - 2
-    width: 6
-  8:
-    K_h: 2
-    K_w: 1
-    height: 12
-    input_channels: 256
-    output_channels: 64
-    strides:
-    - 1
-    - 1
-    width: 8
-  9:
-    K_h: 2
-    K_w: 5
-    height: 7
-    input_channels: 512
-    output_channels: 32
-    strides:
-    - 1
-    - 1
-    width: 6
-  10:
-    K_h: 1
-    K_w: 3
-    height: 12
-    input_channels: 512
-    output_channels: 32
-    strides:
-    - 1
-    - 2
-    width: 6
-  11:
-    K_h: 2
     K_w: 4
     height: 10
     input_channels: 256
+    num_threads: 2
+    output_channels: 64
+    strides:
+    - 2
+    - 2
+    width: 11
+  7:
+    K_h: 3
+    K_w: 5
+    height: 7
+    input_channels: 256
+    num_threads: 1
     output_channels: 32
     strides:
     - 2
+    - 2
+    width: 8
+  8:
+    K_h: 3
+    K_w: 1
+    height: 12
+    input_channels: 512
+    num_threads: 2
+    output_channels: 32
+    strides:
+    - 1
+    - 2
+    width: 8
+  9:
+    K_h: 1
+    K_w: 5
+    height: 10
+    input_channels: 512
+    num_threads: 1
+    output_channels: 64
+    strides:
+    - 1
+    - 2
+    width: 8
+  10:
+    K_h: 2
+    K_w: 1
+    height: 12
+    input_channels: 512
+    num_threads: 5
+    output_channels: 64
+    strides:
+    - 2
+    - 2
+    width: 6
+  11:
+    K_h: 3
+    K_w: 4
+    height: 7
+    input_channels: 256
+    num_threads: 1
+    output_channels: 64
+    strides:
+    - 1
     - 1
     width: 11
   12:
@@ -126,66 +138,73 @@ default:
     K_w: 4
     height: 12
     input_channels: 512
+    num_threads: 5
     output_channels: 64
     strides:
     - 2
     - 2
-    width: 11
+    width: 8
   13:
-    K_h: 6
+    K_h: 3
+    K_w: 5
+    height: 7
+    input_channels: 512
+    num_threads: 2
+    output_channels: 32
+    strides:
+    - 1
+    - 1
+    width: 11
+  14:
+    K_h: 2
+    K_w: 4
+    height: 7
+    input_channels: 512
+    num_threads: 1
+    output_channels: 32
+    strides:
+    - 2
+    - 1
+    width: 11
+  15:
+    K_h: 2
+    K_w: 3
+    height: 7
+    input_channels: 256
+    num_threads: 2
+    output_channels: 32
+    strides:
+    - 1
+    - 1
+    width: 6
+  16:
+    K_h: 2
     K_w: 1
     height: 12
-    input_channels: 256
-    output_channels: 64
-    strides:
-    - 2
-    - 2
-    width: 6
-  14:
-    K_h: 1
-    K_w: 1
-    height: 10
     input_channels: 512
-    output_channels: 32
-    strides:
-    - 1
-    - 1
-    width: 8
-  15:
-    K_h: 6
-    K_w: 3
-    height: 7
-    input_channels: 512
-    output_channels: 32
-    strides:
-    - 2
-    - 2
-    width: 8
-  16:
-    K_h: 3
-    K_w: 3
-    height: 10
-    input_channels: 256
+    num_threads: 2
     output_channels: 64
     strides:
     - 2
     - 1
-    width: 8
+    width: 11
   17:
     K_h: 3
-    K_w: 1
-    height: 7
-    input_channels: 256
-    output_channels: 64
-    strides:
-    - 2
-    - 2
-    width: 8
-  18:
-    K_h: 3
-    K_w: 4
+    K_w: 5
     height: 10
     input_channels: 256
+    num_threads: 2
+    output_channels: 32
+    strides:
+    - 2
+    - 1
+    width: 8
+  18:
+    K_h: 1
+    K_w: 3
+    height: 10
+    input_channels: 512
+    num_threads: 5
     output_channels: 32
     strides:
     - 2
@@ -195,9 +214,10 @@ default:
     K_h: 1
     K_w: 5
     height: 12
-    input_channels: 256
-    output_channels: 64
+    input_channels: 512
+    num_threads: 5
+    output_channels: 32
     strides:
     - 2
     - 1
-    width: 8
+    width: 6

--- a/test/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8.yml
+++ b/test/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8.yml
@@ -2,23 +2,11 @@
 # RANDOMLY GENERATED CONFIGS, MODIFY AT OWN RISK
 default:
   0:
-    K_h: 6
-    K_w: 3
-    height: 10
-    input_channels: 128
-    output_channels: 32
-    output_range:
-    - 0
-    - 3
-    strides:
-    - 1
-    - 1
-    width: 6
-  1:
-    K_h: 6
-    K_w: 3
-    height: 10
-    input_channels: 32
+    K_h: 3
+    K_w: 1
+    height: 7
+    input_channels: 320
+    num_threads: 1
     output_channels: 4
     output_range:
     - -4
@@ -26,207 +14,181 @@ default:
     strides:
     - 1
     - 1
-    width: 6
-  2:
-    K_h: 6
-    K_w: 3
-    height: 12
+    width: 11
+  1:
+    K_h: 1
+    K_w: 5
+    height: 10
     input_channels: 128
-    output_channels: 32
+    num_threads: 2
+    output_channels: 4
     output_range:
     - -4
     - 1
     strides:
-    - 1
     - 2
-    width: 6
+    - 1
+    width: 11
+  2:
+    K_h: 3
+    K_w: 3
+    height: 7
+    input_channels: 128
+    num_threads: 5
+    output_channels: 28
+    output_range:
+    - -2
+    - 5
+    strides:
+    - 2
+    - 1
+    width: 8
   3:
     K_h: 1
     K_w: 4
-    height: 10
+    height: 12
     input_channels: 320
+    num_threads: 5
     output_channels: 32
     output_range:
-    - -2
+    - -4
     - 1
     strides:
-    - 1
     - 2
-    width: 11
+    - 1
+    width: 8
   4:
     K_h: 2
-    K_w: 1
+    K_w: 4
     height: 12
     input_channels: 32
+    num_threads: 1
     output_channels: 28
     output_range:
-    - -4
-    - 5
+    - 0
+    - 3
     strides:
     - 1
-    - 2
-    width: 8
+    - 1
+    width: 6
   5:
     K_h: 6
     K_w: 1
-    height: 7
-    input_channels: 32
-    output_channels: 32
+    height: 10
+    input_channels: 320
+    num_threads: 2
+    output_channels: 28
     output_range:
     - 0
     - 1
     strides:
     - 2
     - 2
-    width: 11
+    width: 6
   6:
-    K_h: 1
-    K_w: 4
-    height: 10
-    input_channels: 32
+    K_h: 2
+    K_w: 1
+    height: 12
+    input_channels: 128
+    num_threads: 1
     output_channels: 28
     output_range:
-    - -2
+    - -4
     - 5
     strides:
     - 2
     - 2
-    width: 11
+    width: 6
   7:
-    K_h: 3
+    K_h: 2
     K_w: 5
-    height: 7
+    height: 12
     input_channels: 32
+    num_threads: 2
     output_channels: 4
     output_range:
-    - -4
-    - 3
+    - 0
+    - 1
     strides:
     - 2
-    - 2
-    width: 8
+    - 1
+    width: 6
   8:
-    K_h: 3
-    K_w: 1
-    height: 12
+    K_h: 1
+    K_w: 3
+    height: 10
     input_channels: 320
-    output_channels: 28
+    num_threads: 5
+    output_channels: 32
     output_range:
-    - -2
-    - 1
+    - 0
+    - 5
     strides:
-    - 1
+    - 2
     - 2
     width: 8
   9:
     K_h: 1
-    K_w: 5
-    height: 10
-    input_channels: 320
-    output_channels: 28
+    K_w: 4
+    height: 7
+    input_channels: 32
+    num_threads: 2
+    output_channels: 4
     output_range:
-    - -4
+    - -2
     - 3
     strides:
     - 1
     - 2
-    width: 8
+    width: 11
   10:
-    K_h: 2
+    K_h: 6
     K_w: 1
-    height: 12
+    height: 10
     input_channels: 128
-    output_channels: 28
+    num_threads: 1
+    output_channels: 4
     output_range:
     - 0
-    - 1
-    strides:
-    - 2
-    - 2
-    width: 6
-  11:
-    K_h: 3
-    K_w: 4
-    height: 7
-    input_channels: 128
-    output_channels: 28
-    output_range:
-    - -4
     - 5
     strides:
     - 1
+    - 2
+    width: 11
+  11:
+    K_h: 6
+    K_w: 3
+    height: 12
+    input_channels: 320
+    num_threads: 5
+    output_channels: 28
+    output_range:
+    - -2
     - 1
+    strides:
+    - 1
+    - 2
     width: 11
   12:
     K_h: 6
-    K_w: 4
+    K_w: 5
     height: 12
-    input_channels: 320
+    input_channels: 32
+    num_threads: 1
     output_channels: 32
     output_range:
     - 0
-    - 5
-    strides:
-    - 2
-    - 2
-    width: 8
-  13:
-    K_h: 3
-    K_w: 5
-    height: 7
-    input_channels: 320
-    output_channels: 4
-    output_range:
-    - -2
-    - 5
-    strides:
     - 1
-    - 1
-    width: 11
-  14:
-    K_h: 2
-    K_w: 4
-    height: 7
-    input_channels: 128
-    output_channels: 4
-    output_range:
-    - -4
-    - 1
-    strides:
-    - 2
-    - 1
-    width: 11
-  15:
-    K_h: 2
-    K_w: 3
-    height: 7
-    input_channels: 32
-    output_channels: 4
-    output_range:
-    - -2
-    - 5
     strides:
     - 1
     - 1
     width: 6
-  16:
+  13:
     K_h: 2
-    K_w: 1
-    height: 12
-    input_channels: 320
-    output_channels: 32
-    output_range:
-    - -2
-    - 3
-    strides:
-    - 2
-    - 1
-    width: 11
-  17:
-    K_h: 3
     K_w: 5
-    height: 10
+    height: 7
     input_channels: 128
+    num_threads: 5
     output_channels: 28
     output_range:
     - -2
@@ -235,29 +197,87 @@ default:
     - 2
     - 1
     width: 8
-  18:
-    K_h: 1
-    K_w: 3
+  14:
+    K_h: 3
+    K_w: 4
     height: 10
-    input_channels: 128
+    input_channels: 32
+    num_threads: 5
     output_channels: 4
     output_range:
     - 0
     - 5
     strides:
     - 2
-    - 1
-    width: 6
-  19:
-    K_h: 1
-    K_w: 5
-    height: 12
-    input_channels: 320
+    - 2
+    width: 8
+  15:
+    K_h: 6
+    K_w: 3
+    height: 10
+    input_channels: 32
+    num_threads: 2
     output_channels: 4
     output_range:
-    - 0
+    - -4
+    - 3
+    strides:
+    - 1
+    - 1
+    width: 11
+  16:
+    K_h: 3
+    K_w: 1
+    height: 12
+    input_channels: 128
+    num_threads: 5
+    output_channels: 32
+    output_range:
+    - -2
+    - 1
+    strides:
+    - 1
+    - 1
+    width: 6
+  17:
+    K_h: 1
+    K_w: 4
+    height: 7
+    input_channels: 128
+    num_threads: 2
+    output_channels: 32
+    output_range:
+    - -4
+    - 5
+    strides:
+    - 1
+    - 2
+    width: 11
+  18:
+    K_h: 2
+    K_w: 3
+    height: 10
+    input_channels: 320
+    num_threads: 2
+    output_channels: 28
+    output_range:
+    - -4
     - 3
     strides:
     - 2
+    - 2
+    width: 8
+  19:
+    K_h: 3
+    K_w: 5
+    height: 7
+    input_channels: 320
+    num_threads: 1
+    output_channels: 32
+    output_range:
+    - -2
+    - 5
+    strides:
     - 1
-    width: 6
+    - 2
+    width: 8

--- a/test/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO.yml
+++ b/test/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO.yml
@@ -2,128 +2,152 @@
 # RANDOMLY GENERATED CONFIGS, MODIFY AT OWN RISK
 default:
   0:
-    K_h: 1
-    K_w: 3
+    K_h: 2
+    K_w: 4
     height: 7
-    input_channels: 512
-    output_channels: 48
+    input_channels: 256
+    num_threads: 1
+    output_channels: 16
     output_range:
     - -2
-    - 3
+    - 5
     strides:
-    - 1
+    - 2
     - 2
     width: 8
   1:
-    K_h: 6
+    K_h: 3
     K_w: 3
     height: 7
-    input_channels: 256
+    input_channels: 512
+    num_threads: 2
     output_channels: 16
     output_range:
-    - 0
-    - 5
-    strides:
-    - 2
+    - -2
     - 1
-    width: 11
+    strides:
+    - 1
+    - 2
+    width: 8
   2:
     K_h: 2
     K_w: 4
-    height: 12
+    height: 7
     input_channels: 256
+    num_threads: 1
     output_channels: 16
     output_range:
-    - -4
+    - 0
     - 1
     strides:
     - 2
     - 2
-    width: 11
+    width: 8
   3:
-    K_h: 3
-    K_w: 3
-    height: 10
-    input_channels: 256
-    output_channels: 48
-    output_range:
-    - -4
-    - 5
-    strides:
-    - 2
-    - 2
-    width: 6
-  4:
-    K_h: 3
-    K_w: 4
+    K_h: 6
+    K_w: 5
     height: 12
-    input_channels: 512
-    output_channels: 48
+    input_channels: 256
+    num_threads: 1
+    output_channels: 16
     output_range:
-    - -4
-    - 5
+    - 0
+    - 1
     strides:
     - 1
     - 2
-    width: 11
-  5:
-    K_h: 2
-    K_w: 3
-    height: 10
-    input_channels: 512
+    width: 8
+  4:
+    K_h: 1
+    K_w: 1
+    height: 7
+    input_channels: 256
+    num_threads: 2
     output_channels: 48
     output_range:
     - -4
     - 3
     strides:
-    - 2
     - 1
+    - 1
+    width: 11
+  5:
+    K_h: 3
+    K_w: 4
+    height: 10
+    input_channels: 256
+    num_threads: 1
+    output_channels: 48
+    output_range:
+    - -2
+    - 1
+    strides:
+    - 2
+    - 2
     width: 8
   6:
+    K_h: 3
+    K_w: 1
+    height: 12
+    input_channels: 512
+    num_threads: 2
+    output_channels: 48
+    output_range:
+    - -2
+    - 1
+    strides:
+    - 1
+    - 1
+    width: 6
+  7:
     K_h: 1
     K_w: 5
     height: 7
-    input_channels: 256
-    output_channels: 16
+    input_channels: 512
+    num_threads: 5
+    output_channels: 48
     output_range:
     - 0
     - 3
     strides:
     - 2
-    - 1
-    width: 6
-  7:
-    K_h: 2
-    K_w: 4
-    height: 7
-    input_channels: 512
-    output_channels: 16
-    output_range:
-    - -4
-    - 5
-    strides:
-    - 1
     - 1
     width: 6
   8:
     K_h: 6
-    K_w: 1
-    height: 7
-    input_channels: 512
+    K_w: 4
+    height: 10
+    input_channels: 256
+    num_threads: 5
     output_channels: 16
     output_range:
-    - -4
-    - 1
+    - -2
+    - 3
     strides:
+    - 2
     - 1
-    - 1
-    width: 8
+    width: 6
   9:
     K_h: 6
-    K_w: 5
+    K_w: 3
     height: 12
     input_channels: 256
-    output_channels: 16
+    num_threads: 5
+    output_channels: 48
+    output_range:
+    - 0
+    - 3
+    strides:
+    - 2
+    - 1
+    width: 11
+  10:
+    K_h: 1
+    K_w: 3
+    height: 10
+    input_channels: 512
+    num_threads: 2
+    output_channels: 48
     output_range:
     - -4
     - 3
@@ -131,172 +155,129 @@ default:
     - 2
     - 2
     width: 11
-  10:
-    K_h: 6
-    K_w: 4
-    height: 10
-    input_channels: 256
-    output_channels: 48
+  11:
+    K_h: 3
+    K_w: 5
+    height: 12
+    input_channels: 512
+    num_threads: 1
+    output_channels: 16
     output_range:
-    - -2
+    - -4
     - 1
     strides:
     - 1
     - 2
-    width: 6
-  11:
-    K_h: 6
-    K_w: 5
-    height: 10
-    input_channels: 256
-    output_channels: 16
-    output_range:
-    - -2
-    - 3
-    strides:
-    - 1
-    - 1
-    width: 6
+    width: 11
   12:
     K_h: 1
-    K_w: 5
-    height: 12
-    input_channels: 256
-    output_channels: 16
+    K_w: 1
+    height: 10
+    input_channels: 512
+    num_threads: 5
+    output_channels: 48
     output_range:
-    - -2
-    - 5
+    - -4
+    - 1
     strides:
+    - 1
     - 2
-    - 2
-    width: 11
+    width: 8
   13:
     K_h: 3
-    K_w: 3
+    K_w: 5
     height: 12
     input_channels: 512
-    output_channels: 48
-    output_range:
-    - -2
-    - 3
-    strides:
-    - 1
-    - 2
-    width: 11
-  14:
-    K_h: 3
-    K_w: 1
-    height: 10
-    input_channels: 512
-    output_channels: 48
-    output_range:
-    - 0
-    - 1
-    strides:
-    - 2
-    - 2
-    width: 8
-  15:
-    K_h: 1
-    K_w: 1
-    height: 10
-    input_channels: 256
-    output_channels: 48
-    output_range:
-    - 0
-    - 5
-    strides:
-    - 1
-    - 1
-    width: 8
-  16:
-    K_h: 2
-    K_w: 4
-    height: 7
-    input_channels: 512
-    output_channels: 48
-    output_range:
-    - 0
-    - 3
-    strides:
-    - 1
-    - 1
-    width: 8
-  17:
-    K_h: 3
-    K_w: 1
-    height: 10
-    input_channels: 256
+    num_threads: 5
     output_channels: 16
     output_range:
-    - -2
+    - 0
+    - 1
+    strides:
+    - 1
+    - 2
+    width: 6
+  14:
+    K_h: 2
+    K_w: 5
+    height: 10
+    input_channels: 512
+    num_threads: 5
+    output_channels: 16
+    output_range:
+    - -4
+    - 5
+    strides:
+    - 1
+    - 1
+    width: 6
+  15:
+    K_h: 2
+    K_w: 1
+    height: 12
+    input_channels: 256
+    num_threads: 1
+    output_channels: 48
+    output_range:
+    - 0
     - 5
     strides:
     - 2
+    - 1
+    width: 11
+  16:
+    K_h: 2
+    K_w: 3
+    height: 10
+    input_channels: 512
+    num_threads: 2
+    output_channels: 16
+    output_range:
+    - 0
+    - 5
+    strides:
+    - 2
+    - 2
+    width: 6
+  17:
+    K_h: 6
+    K_w: 4
+    height: 7
+    input_channels: 256
+    num_threads: 2
+    output_channels: 48
+    output_range:
+    - -2
+    - 5
+    strides:
+    - 1
     - 1
     width: 6
   18:
-    K_h: 2
-    K_w: 5
-    height: 10
+    K_h: 1
+    K_w: 3
+    height: 7
     input_channels: 512
+    num_threads: 1
     output_channels: 48
     output_range:
-    - 0
-    - 5
+    - -2
+    - 3
     strides:
-    - 2
     - 1
-    width: 8
+    - 1
+    width: 11
   19:
-    K_h: 1
+    K_h: 6
     K_w: 1
     height: 12
-    input_channels: 512
-    output_channels: 16
-    output_range:
-    - -2
-    - 1
-    strides:
-    - 1
-    - 2
-    width: 11
-  20:
-    K_h: 6
-    K_w: 4
-    height: 12
     input_channels: 256
+    num_threads: 5
     output_channels: 16
     output_range:
-    - 0
-    - 1
+    - -4
+    - 3
     strides:
     - 2
     - 1
-    width: 8
-  21:
-    K_h: 6
-    K_w: 5
-    height: 10
-    input_channels: 512
-    output_channels: 16
-    output_range:
-    - 0
-    - 1
-    strides:
-    - 2
-    - 2
-    width: 6
-  22:
-    K_h: 3
-    K_w: 3
-    height: 12
-    input_channels: 512
-    output_channels: 16
-    output_range:
-    - 0
-    - 1
-    strides:
-    - 1
-    - 2
     width: 11

--- a/test/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO_activation.yml
+++ b/test/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_DIDO_activation.yml
@@ -4,38 +4,11 @@ default:
   0:
     K_h: 3
     K_w: 3
-    activation: relu6
-    height: 12
-    input_channels: 256
-    output_channels: 48
-    output_range:
-    - 0
-    - 1
-    strides:
-    - 2
-    - 1
-    width: 6
-  1:
-    K_h: 1
-    K_w: 5
-    activation: relu6
-    height: 10
-    input_channels: 512
-    output_channels: 16
-    output_range:
-    - 0
-    - 5
-    strides:
-    - 2
-    - 1
-    width: 11
-  2:
-    K_h: 1
-    K_w: 5
     activation: relu
-    height: 12
+    height: 7
     input_channels: 512
-    output_channels: 16
+    num_threads: 2
+    output_channels: 48
     output_range:
     - -4
     - 1
@@ -43,241 +16,288 @@ default:
     - 1
     - 2
     width: 6
-  3:
+  1:
     K_h: 2
-    K_w: 3
-    activation: relu
-    height: 10
-    input_channels: 512
-    output_channels: 16
-    output_range:
-    - 0
-    - 3
-    strides:
-    - 1
-    - 1
-    width: 11
-  4:
-    K_h: 6
-    K_w: 1
+    K_w: 4
     activation: relu6
     height: 10
-    input_channels: 256
+    input_channels: 512
+    num_threads: 2
     output_channels: 48
     output_range:
     - -2
-    - 5
+    - 1
     strides:
     - 2
     - 2
     width: 8
-  5:
-    K_h: 1
-    K_w: 3
-    activation: relu
-    height: 7
-    input_channels: 512
+  2:
+    K_h: 2
+    K_w: 5
+    activation: relu6
+    height: 12
+    input_channels: 256
+    num_threads: 1
     output_channels: 16
     output_range:
-    - -4
+    - 0
     - 5
     strides:
     - 1
     - 1
+    width: 6
+  3:
+    K_h: 1
+    K_w: 4
+    activation: relu
+    height: 12
+    input_channels: 256
+    num_threads: 5
+    output_channels: 16
+    output_range:
+    - -2
+    - 1
+    strides:
+    - 1
+    - 1
+    width: 8
+  4:
+    K_h: 6
+    K_w: 4
+    activation: relu
+    height: 12
+    input_channels: 512
+    num_threads: 1
+    output_channels: 48
+    output_range:
+    - -2
+    - 3
+    strides:
+    - 1
+    - 1
+    width: 8
+  5:
+    K_h: 1
+    K_w: 3
+    activation: relu6
+    height: 12
+    input_channels: 512
+    num_threads: 2
+    output_channels: 48
+    output_range:
+    - 0
+    - 1
+    strides:
+    - 1
+    - 2
     width: 8
   6:
     K_h: 2
     K_w: 5
     activation: relu6
+    height: 10
+    input_channels: 256
+    num_threads: 5
+    output_channels: 48
+    output_range:
+    - -4
+    - 5
+    strides:
+    - 2
+    - 2
+    width: 8
+  7:
+    K_h: 3
+    K_w: 1
+    activation: relu6
     height: 7
     input_channels: 256
+    num_threads: 2
     output_channels: 16
     output_range:
-    - 0
-    - 1
+    - -2
+    - 5
     strides:
     - 2
     - 1
-    width: 6
-  7:
-    K_h: 2
-    K_w: 5
-    activation: relu6
-    height: 10
-    input_channels: 256
+    width: 11
+  8:
+    K_h: 6
+    K_w: 1
+    activation: relu
+    height: 12
+    input_channels: 512
+    num_threads: 5
     output_channels: 48
     output_range:
     - -2
     - 5
     strides:
     - 2
-    - 2
-    width: 11
-  8:
-    K_h: 6
+    - 1
+    width: 6
+  9:
+    K_h: 1
     K_w: 5
-    activation: relu6
-    height: 12
-    input_channels: 256
+    activation: relu
+    height: 10
+    input_channels: 512
+    num_threads: 5
     output_channels: 48
     output_range:
-    - -2
+    - 0
     - 3
     strides:
-    - 2
-    - 2
-    width: 8
-  9:
-    K_h: 6
-    K_w: 4
-    activation: relu6
-    height: 12
-    input_channels: 512
-    output_channels: 16
-    output_range:
-    - -2
     - 1
-    strides:
-    - 2
     - 1
     width: 11
   10:
     K_h: 2
     K_w: 3
-    activation: relu
+    activation: relu6
     height: 7
     input_channels: 512
-    output_channels: 48
-    output_range:
-    - 0
-    - 3
-    strides:
-    - 2
-    - 2
-    width: 11
-  11:
-    K_h: 1
-    K_w: 1
-    activation: relu6
-    height: 12
-    input_channels: 256
+    num_threads: 1
     output_channels: 16
-    output_range:
-    - -4
-    - 1
-    strides:
-    - 1
-    - 1
-    width: 6
-  12:
-    K_h: 3
-    K_w: 4
-    activation: relu6
-    height: 7
-    input_channels: 512
-    output_channels: 48
     output_range:
     - -4
     - 5
     strides:
+    - 2
     - 1
-    - 1
-    width: 8
-  13:
-    K_h: 3
-    K_w: 1
+    width: 6
+  11:
+    K_h: 1
+    K_w: 4
     activation: relu6
     height: 10
-    input_channels: 512
+    input_channels: 256
+    num_threads: 1
     output_channels: 48
+    output_range:
+    - 0
+    - 5
+    strides:
+    - 2
+    - 1
+    width: 11
+  12:
+    K_h: 6
+    K_w: 1
+    activation: relu6
+    height: 12
+    input_channels: 512
+    num_threads: 1
+    output_channels: 16
     output_range:
     - -2
     - 3
     strides:
-    - 2
     - 1
-    width: 8
-  14:
-    K_h: 1
+    - 2
+    width: 11
+  13:
+    K_h: 6
     K_w: 3
     activation: relu
-    height: 12
+    height: 7
     input_channels: 512
+    num_threads: 2
     output_channels: 48
     output_range:
     - -4
+    - 3
+    strides:
+    - 2
+    - 2
+    width: 8
+  14:
+    K_h: 2
+    K_w: 1
+    activation: relu6
+    height: 10
+    input_channels: 256
+    num_threads: 1
+    output_channels: 16
+    output_range:
+    - -2
     - 1
     strides:
-    - 1
     - 2
-    width: 6
+    - 2
+    width: 8
   15:
     K_h: 3
-    K_w: 4
+    K_w: 5
     activation: relu
     height: 7
     input_channels: 256
-    output_channels: 16
+    num_threads: 2
+    output_channels: 48
     output_range:
-    - -4
-    - 5
+    - 0
+    - 3
     strides:
     - 1
     - 2
     width: 11
   16:
-    K_h: 6
-    K_w: 1
-    activation: relu
-    height: 10
-    input_channels: 256
-    output_channels: 16
-    output_range:
-    - 0
-    - 5
-    strides:
-    - 2
-    - 2
-    width: 8
-  17:
-    K_h: 6
+    K_h: 1
     K_w: 1
     activation: relu
     height: 12
     input_channels: 256
-    output_channels: 48
-    output_range:
-    - -4
-    - 3
-    strides:
-    - 1
-    - 2
-    width: 6
-  18:
-    K_h: 2
-    K_w: 4
-    activation: relu
-    height: 10
-    input_channels: 256
-    output_channels: 48
+    num_threads: 2
+    output_channels: 16
     output_range:
     - 0
     - 3
     strides:
     - 1
     - 1
-    width: 8
-  19:
+    width: 6
+  17:
     K_h: 3
-    K_w: 4
+    K_w: 5
+    activation: relu6
+    height: 10
+    input_channels: 256
+    num_threads: 5
+    output_channels: 16
+    output_range:
+    - -4
+    - 1
+    strides:
+    - 2
+    - 1
+    width: 11
+  18:
+    K_h: 3
+    K_w: 3
     activation: relu
     height: 7
     input_channels: 512
+    num_threads: 1
     output_channels: 16
     output_range:
-    - -2
-    - 3
+    - 0
+    - 1
     strides:
     - 1
+    - 2
+    width: 11
+  19:
+    K_h: 6
+    K_w: 4
+    activation: relu
+    height: 7
+    input_channels: 256
+    num_threads: 5
+    output_channels: 16
+    output_range:
+    - -4
+    - 3
+    strides:
+    - 2
     - 2
     width: 6

--- a/test/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_activation.yml
+++ b/test/integration_test/test_single_op_models/test_binarized/test_bconv2d_int8_activation.yml
@@ -2,194 +2,253 @@
 # RANDOMLY GENERATED CONFIGS, MODIFY AT OWN RISK
 default:
   0:
-    K_h: 1
-    K_w: 4
-    activation: relu
-    height: 10
-    input_channels: 32
-    output_channels: 32
-    output_range:
-    - 0
-    - 3
-    strides:
-    - 1
-    - 1
-    width: 8
-  1:
-    K_h: 6
-    K_w: 1
-    activation: relu6
-    height: 7
-    input_channels: 128
-    output_channels: 32
-    output_range:
-    - -2
-    - 1
-    strides:
-    - 1
-    - 2
-    width: 11
-  2:
     K_h: 6
     K_w: 3
-    activation: relu
-    height: 10
-    input_channels: 32
-    output_channels: 32
-    output_range:
-    - -4
-    - 3
-    strides:
-    - 1
-    - 1
-    width: 8
-  3:
-    K_h: 6
-    K_w: 4
     activation: relu6
-    height: 12
-    input_channels: 128
-    output_channels: 28
-    output_range:
-    - -2
-    - 1
-    strides:
-    - 1
-    - 2
-    width: 6
-  4:
-    K_h: 1
-    K_w: 3
-    activation: relu6
-    height: 12
-    input_channels: 320
-    output_channels: 32
-    output_range:
-    - -4
-    - 5
-    strides:
-    - 1
-    - 2
-    width: 11
-  5:
-    K_h: 6
-    K_w: 1
-    activation: relu
     height: 7
     input_channels: 32
+    num_threads: 1
     output_channels: 4
     output_range:
     - -2
     - 1
     strides:
     - 2
+    - 1
+    width: 6
+  1:
+    K_h: 3
+    K_w: 1
+    activation: relu6
+    height: 7
+    input_channels: 128
+    num_threads: 2
+    output_channels: 4
+    output_range:
+    - 0
+    - 3
+    strides:
+    - 2
     - 2
     width: 6
-  6:
+  2:
+    K_h: 6
+    K_w: 4
+    activation: relu6
+    height: 10
+    input_channels: 320
+    num_threads: 2
+    output_channels: 28
+    output_range:
+    - -4
+    - 3
+    strides:
+    - 2
+    - 1
+    width: 8
+  3:
     K_h: 3
     K_w: 5
     activation: relu
     height: 7
-    input_channels: 32
-    output_channels: 28
-    output_range:
-    - 0
-    - 1
-    strides:
-    - 1
-    - 1
-    width: 11
-  7:
-    K_h: 1
-    K_w: 1
-    activation: relu
-    height: 7
     input_channels: 320
-    output_channels: 28
+    num_threads: 1
+    output_channels: 32
     output_range:
     - -2
-    - 5
+    - 3
     strides:
-    - 2
+    - 1
     - 2
     width: 8
-  8:
-    K_h: 2
+  4:
+    K_h: 1
     K_w: 5
     activation: relu6
-    height: 10
+    height: 7
     input_channels: 320
-    output_channels: 28
+    num_threads: 5
+    output_channels: 32
     output_range:
-    - -2
+    - -4
+    - 5
+    strides:
+    - 1
+    - 1
+    width: 8
+  5:
+    K_h: 2
+    K_w: 4
+    activation: relu
+    height: 10
+    input_channels: 32
+    num_threads: 1
+    output_channels: 32
+    output_range:
+    - -4
     - 3
     strides:
     - 2
     - 2
     width: 8
-  9:
+  6:
     K_h: 2
-    K_w: 1
+    K_w: 4
     activation: relu6
     height: 10
     input_channels: 128
+    num_threads: 2
     output_channels: 4
     output_range:
     - -4
     - 1
+    strides:
+    - 2
+    - 1
+    width: 11
+  7:
+    K_h: 6
+    K_w: 4
+    activation: relu
+    height: 10
+    input_channels: 320
+    num_threads: 2
+    output_channels: 4
+    output_range:
+    - -4
+    - 3
+    strides:
+    - 1
+    - 2
+    width: 11
+  8:
+    K_h: 2
+    K_w: 5
+    activation: relu6
+    height: 7
+    input_channels: 32
+    num_threads: 1
+    output_channels: 32
+    output_range:
+    - 0
+    - 5
+    strides:
+    - 2
+    - 2
+    width: 6
+  9:
+    K_h: 3
+    K_w: 4
+    activation: relu
+    height: 10
+    input_channels: 32
+    num_threads: 1
+    output_channels: 28
+    output_range:
+    - 0
+    - 5
     strides:
     - 1
     - 1
     width: 8
   10:
-    K_h: 3
+    K_h: 6
     K_w: 1
     activation: relu
-    height: 12
+    height: 10
     input_channels: 320
-    output_channels: 4
+    num_threads: 5
+    output_channels: 28
     output_range:
-    - 0
-    - 1
+    - -2
+    - 3
     strides:
     - 2
     - 1
     width: 11
   11:
-    K_h: 3
-    K_w: 4
-    activation: relu
-    height: 12
-    input_channels: 320
-    output_channels: 32
-    output_range:
-    - -4
-    - 1
-    strides:
-    - 1
-    - 1
-    width: 8
-  12:
     K_h: 1
-    K_w: 4
-    activation: relu
-    height: 7
+    K_w: 3
+    activation: relu6
+    height: 12
     input_channels: 128
-    output_channels: 32
+    num_threads: 5
+    output_channels: 28
     output_range:
     - 0
-    - 5
+    - 1
+    strides:
+    - 1
+    - 1
+    width: 11
+  12:
+    K_h: 1
+    K_w: 3
+    activation: relu6
+    height: 12
+    input_channels: 128
+    num_threads: 5
+    output_channels: 4
+    output_range:
+    - 0
+    - 3
     strides:
     - 2
-    - 2
+    - 1
     width: 11
   13:
     K_h: 3
-    K_w: 5
+    K_w: 3
     activation: relu6
-    height: 10
-    input_channels: 32
-    output_channels: 4
+    height: 7
+    input_channels: 128
+    num_threads: 1
+    output_channels: 32
+    output_range:
+    - -4
+    - 5
+    strides:
+    - 1
+    - 1
+    width: 11
+  14:
+    K_h: 2
+    K_w: 1
+    activation: relu
+    height: 12
+    input_channels: 128
+    num_threads: 5
+    output_channels: 28
+    output_range:
+    - 0
+    - 3
+    strides:
+    - 1
+    - 1
+    width: 6
+  15:
+    K_h: 6
+    K_w: 5
+    activation: relu
+    height: 12
+    input_channels: 320
+    num_threads: 1
+    output_channels: 28
+    output_range:
+    - -2
+    - 1
+    strides:
+    - 1
+    - 2
+    width: 6
+  16:
+    K_h: 1
+    K_w: 1
+    activation: relu
+    height: 12
+    input_channels: 128
+    num_threads: 5
+    output_channels: 28
     output_range:
     - -2
     - 5
@@ -197,87 +256,48 @@ default:
     - 2
     - 2
     width: 6
-  14:
-    K_h: 6
-    K_w: 4
-    activation: relu6
-    height: 12
-    input_channels: 32
-    output_channels: 4
-    output_range:
-    - -2
-    - 5
-    strides:
-    - 1
-    - 2
-    width: 11
-  15:
-    K_h: 2
-    K_w: 3
+  17:
+    K_h: 1
+    K_w: 1
     activation: relu
-    height: 10
+    height: 12
     input_channels: 320
+    num_threads: 2
     output_channels: 4
     output_range:
-    - -2
-    - 3
-    strides:
-    - 2
+    - 0
     - 1
-    width: 11
-  16:
-    K_h: 2
+    strides:
+    - 1
+    - 2
+    width: 8
+  18:
+    K_h: 3
     K_w: 5
     activation: relu6
-    height: 10
-    input_channels: 128
+    height: 7
+    input_channels: 32
+    num_threads: 5
     output_channels: 32
     output_range:
     - -4
     - 1
     strides:
     - 2
-    - 1
-    width: 6
-  17:
+    - 2
+    width: 11
+  19:
     K_h: 2
     K_w: 3
-    activation: relu6
-    height: 7
-    input_channels: 128
-    output_channels: 28
-    output_range:
-    - -4
-    - 5
-    strides:
-    - 2
-    - 1
-    width: 8
-  18:
-    K_h: 3
-    K_w: 3
-    activation: relu6
-    height: 12
-    input_channels: 320
-    output_channels: 28
-    output_range:
-    - 0
-    - 5
-    strides:
-    - 2
-    - 1
-    width: 6
-  19:
-    K_h: 1
-    K_w: 5
     activation: relu
-    height: 7
-    input_channels: 128
+    height: 10
+    input_channels: 32
+    num_threads: 2
     output_channels: 4
     output_range:
-    - 0
-    - 3
+    - -2
+    - 5
     strides:
     - 1
     - 2
-    width: 6
+    width: 8


### PR DESCRIPTION
Adds parallelization options to bconv2d integration tests and updates submodules to enable parallelized ops. Line changes due solely to updated test config .yml and generate notebook.