### PR TITLE
Try mounting the bazel cache from the docker host

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                 """
                 sh ". activate ./ai_tools_venv && make tflite2xcore_dist"
                 sh """. activate ./ai_tools_venv && cd experimental/xformer &&
-                      bazel --output_user_root=/tmp/bazel build //:xcore-opt
+                      bazel --output_user_root=/tmp/bazel/.cache build //:xcore-opt
                 """
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ getApproval()
 pipeline {
     agent {
         dockerfile {
-            args "-v /home/jenkins/.cache/bazel:/tmp/bazel -v /home/jenkins/.keras:/root/.keras -v /etc/passwd:/etc/passwd:ro"
+            args "-v /home/jenkins/.cache/bazel:/home/jenkins/.cache/bazel -v /home/jenkins/.keras:/root/.keras -v /etc/passwd:/etc/passwd:ro"
         }
     }
 
@@ -76,7 +76,7 @@ pipeline {
                 """
                 sh ". activate ./ai_tools_venv && make tflite2xcore_dist"
                 sh """. activate ./ai_tools_venv && cd experimental/xformer &&
-                      bazel --output_user_root=/tmp/bazel/.cache build //:xcore-opt
+                      bazel build //:xcore-opt
                 """
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ getApproval()
 pipeline {
     agent {
         dockerfile {
-            args "-v /home/jenkins/.cache/bazel:/home/jenkins/.cache/bazel -v /home/jenkins/.keras:/root/.keras -v /etc/passwd:/etc/passwd:ro"
+            args "-v /home/jenkins/.keras:/root/.keras -v /etc/passwd:/etc/passwd:ro"
         }
     }
 
@@ -76,7 +76,7 @@ pipeline {
                 """
                 sh ". activate ./ai_tools_venv && make tflite2xcore_dist"
                 sh """. activate ./ai_tools_venv && cd experimental/xformer &&
-                      bazel build //:xcore-opt
+                      bazel build --remote_cache=http://srv-bri-bld-cache:8080 //:xcore-opt
                 """
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                 """
                 sh ". activate ./ai_tools_venv && make tflite2xcore_dist"
                 sh """. activate ./ai_tools_venv && cd experimental/xformer &&
-                      bazel build --remote_cache=http://srv-bri-bld-cache:8080 //:xcore-opt
+                      bazel build --remote_cache=http://10.128.5.229:8080 //:xcore-opt
                 """
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                 """
                 sh ". activate ./ai_tools_venv && make tflite2xcore_dist"
                 sh """. activate ./ai_tools_venv && cd experimental/xformer &&
-                      bazel --verbose_failures build --remote_cache=http://10.128.5.229:8080 //:xcore-opt
+                      bazel build --verbose_failures --remote_cache=http://10.128.5.229:8080 //:xcore-opt
                 """
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ getApproval()
 pipeline {
     agent {
         dockerfile {
-            args "-v /home/jenkins/.keras:/root/.keras -v /etc/passwd:/etc/passwd:ro"
+            args "-v /home/jenkins/.cache/bazel:/root/.cache/bazel -v /home/jenkins/.keras:/root/.keras -v /etc/passwd:/etc/passwd:ro"
         }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ getApproval()
 pipeline {
     agent {
         dockerfile {
-            args "-v /home/jenkins/.cache/bazel:/root/.cache/bazel -v /home/jenkins/.keras:/root/.keras -v /etc/passwd:/etc/passwd:ro"
+            args "-v /home/jenkins/.cache/bazel:/tmp/bazel -v /home/jenkins/.keras:/root/.keras -v /etc/passwd:/etc/passwd:ro"
         }
     }
 
@@ -76,7 +76,7 @@ pipeline {
                 """
                 sh ". activate ./ai_tools_venv && make tflite2xcore_dist"
                 sh """. activate ./ai_tools_venv && cd experimental/xformer &&
-                      bazel build //:xcore-opt
+                      bazel --output_user_root=/tmp/bazel build //:xcore-opt
                 """
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                 """
                 sh ". activate ./ai_tools_venv && make tflite2xcore_dist"
                 sh """. activate ./ai_tools_venv && cd experimental/xformer &&
-                      bazel build --remote_cache=http://10.128.5.229:8080 //:xcore-opt
+                      bazel --verbose_failures build --remote_cache=http://10.128.5.229:8080 //:xcore-opt
                 """
             }
         }


### PR DESCRIPTION
In order to decrease build times it has been suggested we implement some form of build caching during the bazel build step.

There are a couple of options:
- [remote caching](https://docs.bazel.build/versions/main/remote-caching.html) would involve maintaining a server running webdav via nginx or similar
- local caching may be achieved by bind mounting from the docker host into the docker container on Jenkins

## Trying local mounting first
- run build a few times (making sure at least two run on same host) and see if cache is used and build time is decreased
- unsure about the /root mounting location as container is entered as "jenkins" user
- - /home/jenkins does not however exist
- - maybe we can use an env var to set it for bazel to be somewhere world writable like /tmp/bazel_cache
- - does this mean the .keras mount is not being utilised as well??