### PR TITLE
Add remote caching to bazel build comand

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                 """
                 sh ". activate ./ai_tools_venv && make tflite2xcore_dist"
                 sh """. activate ./ai_tools_venv && cd experimental/xformer &&
-                      bazel build //:xcore-opt
+                      bazel build --remote_cache=http://srv-bri-bld-cache:8080 //:xcore-opt
                 """
             }
         }


### PR DESCRIPTION
Taking advantage of the new bazel build cache server maintained in our network, the `bazel build` step can be reduced from ~24 minutes to ~3 minutes.

http://srv-bri-jcim0:8080/job/XMOS/job/ai_tools/job/feature%252Fbazel_remote_cache/