### PR TITLE
Go back to using internal bazel cache for Jenkins

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: google-github-actions/auth@v0
         continue-on-error: true
         with:
+          create_credentials_file: true
           credentials_json: ${{ secrets.BAZEL_REMOTE_CACHE_JSON_KEY }}
       - name: Build setup
         env:
@@ -105,6 +106,7 @@ jobs:
       - uses: google-github-actions/auth@v0
         continue-on-error: true
         with:
+          create_credentials_file: true
           credentials_json: ${{ secrets.BAZEL_REMOTE_CACHE_JSON_KEY }}
       - name: Build xformer and manylinux2014 wheel in docker
         # The SETUPTOOLS_SCM_PRETEND_VERSION var is passed via docker to the
@@ -166,6 +168,7 @@ jobs:
       - uses: google-github-actions/auth@v0
         continue-on-error: true
         with:
+          create_credentials_file: true
           credentials_json: ${{ secrets.BAZEL_REMOTE_CACHE_JSON_KEY }}
       - name: Configure pagefile
         uses: al-cheb/configure-pagefile-action@v1.2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -200,8 +200,9 @@ jobs:
         shell: cmd
         run: |
           cd %GITHUB_WORKSPACE%/experimental/xformer
+          IF DEFINED GOOGLE_APPLICATION_CREDENTIALS set "BAZEL_EXTRA_ARGS=--remote_cache=${{ env.BAZEL_CACHE_URL }}/${{ runner.os }}-${{ runner.arch }}-python${{ matrix.python-version }} --google_default_credentials --remote_upload_local_results=true --experimental_remote_cache_compression"
           set BAZEL_VC=C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC
-          bazelisk build //:xcore-opt --verbose_failures --local_ram_resources=5120 --action_env PYTHON_BIN_PATH="C:/hostedtoolcache/windows/Python/3.8.10/x64/python.exe" --remote_cache=${{ env.BAZEL_CACHE_URL }}/${{ runner.os }}-${{ runner.arch }}-python${{ matrix.python-version }} --google_default_credentials --remote_upload_local_results=true --experimental_remote_cache_compression --//:disable_version_check
+          bazelisk build //:xcore-opt --verbose_failures --local_ram_resources=5120 --action_env PYTHON_BIN_PATH="C:/hostedtoolcache/windows/Python/3.8.10/x64/python.exe" %BAZEL_EXTRA_ARGS% --//:disable_version_check
       - name: Build windows wheels
         env:
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ env.PRETEND_VERSION }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,7 @@ pipeline {
         }
     }
     environment {
-        BAZEL_CACHE_KEY_FILE = credentials('BAZEL_REMOTE_CACHE_JSON_KEY')
-        BAZEL_CACHE_URL = 'https://storage.googleapis.com/bazel_remote_cache_0/jenkins'
+        BAZEL_CACHE_URL = 'http://srv-bri-bld-cache:8080'
     }
     parameters { // Available to modify on the job page within Jenkins if starting a build
         string( // use to try different tools versions
@@ -84,7 +83,7 @@ pipeline {
                       make build
                 """
                 sh """. activate ./ai_tools_venv && cd experimental/xformer &&
-                      bazel build --remote_cache=${BAZEL_CACHE_URL} --google_credentials=${BAZEL_CACHE_KEY_FILE} //:xcore-opt --verbose_failures --//:disable_version_check
+                      bazel build --remote_cache=${BAZEL_CACHE_URL} //:xcore-opt --verbose_failures --//:disable_version_check
                 """
                 sh """. activate ./ai_tools_venv &&
                       (cd python && python3 setup.py bdist_wheel) &&
@@ -97,7 +96,7 @@ pipeline {
             steps {
                 // xformer2 unit tests
         sh """. activate ./ai_tools_venv && cd experimental/xformer &&
-                      bazel test --remote_cache=${BAZEL_CACHE_URL} --google_credentials=${BAZEL_CACHE_KEY_FILE} //Test:all --verbose_failures --test_output=errors --//:disable_version_check
+                      bazel test --remote_cache=${BAZEL_CACHE_URL} //Test:all --verbose_failures --test_output=errors --//:disable_version_check
                 """
         // xformer2 integration tests
                 sh """. activate ./ai_tools_venv &&


### PR DESCRIPTION
This should reduce our usage of google cloud storage

If there are any other changes to things like github actions triggers, maybe we could add them here as well.