### PR TITLE
Make dependabot check updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "gitsubmodule" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "monthly"
       time: "00:00"
       timezone: "Europe/London"
       


### PR DESCRIPTION
This, in addition to the changes in #728, should reduce our usage of google cloud storage.