### PR TITLE
Fix notebook runner

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,7 +109,7 @@ pipeline {
                 sh """. activate ./ai_tools_venv &&
                     pip install ./python/
                     pip install pytest nbmake
-                    pytest --nbmake ./docs/notebooks/*.ipynb
+                    pytest --nbmake ./docs/notebooks/
                 """
             }
         }

--- a/docs/notebooks/pytest.ini
+++ b/docs/notebooks/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore docs/notebooks/pytorch_to_tflite/


### PR DESCRIPTION
- Fixes the notebook runner (which runs the notebooks as part of CI for regression testing) so that it looks inside subdirectories of `/docs/notebooks`.
- Adds a mypy.ini file so that some files can be excluded