### PR TITLE
remove pyproject.toml

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,0 @@
-[build-system]
-# These are the assumed default build requirements from pip:
-# https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-requires = ["setuptools>=43.0.0", "wheel"]
-build-backend = "setuptools.build_meta"


### PR DESCRIPTION
I believe pyproject.toml is redundant here, leaving this to see if CI passes. Will test separately as well.