### PR TITLE
Fix exception type in base interpreter

### DIFF
--- a/python/xmos_ai_tools/xinterpreters/base/base_interpreter.py
+++ b/python/xmos_ai_tools/xinterpreters/base/base_interpreter.py
@@ -241,7 +241,7 @@ class xcore_tflm_base_interpreter(ABC):
             ):
                 dtype = np.float32
             else:
-                raise Exception
+                raise TypeError
 
             details = {
                 "name": str(modelBuf.Subgraphs(0).Tensors(tensorIndex).Name())[


### PR DESCRIPTION
Change the exception raised when an input tensor type is not one of the supported types (int8, int32 or float32) from Exception to TypeError, which more accurately describes the reason for the issue.