### PR TITLE
fix strided slice if first dimension is not 1

### DIFF
--- a/xformer/Transforms/ReplaceSlice.cpp
+++ b/xformer/Transforms/ReplaceSlice.cpp
@@ -66,9 +66,9 @@ struct ReplaceSlicePattern : public OpRewritePattern<TFL::SliceOp> {
     const int rank = inputType.getRank();
     const int numPad = 5 - rank;
     for (int i = 0; i < 5; i++) {
-      begin[i] = i > numPad ? beginValues[i - numPad] : 0;
-      end[i] = i > numPad ? begin[i] + sizeValues[i - numPad] : 1;
-      inShape[i] = i > numPad ? inputType.getShape()[i - numPad] : 1;
+      begin[i] = i >= numPad ? beginValues[i - numPad] : 0;
+      end[i] = i >= numPad ? begin[i] + sizeValues[i - numPad] : 1;
+      inShape[i] = i >= numPad ? inputType.getShape()[i - numPad] : 1;
     }
 
     // Merge axes where possible in the end


### PR DESCRIPTION
- fix the replace slice pass in case the first dimension isn't 1.

This wasn't caught by CI because any sensible model has a batch size of 1, but caused an infinite loop when converting a pre-trained `mobilenet_v1` (which included shape -> strided_slice ops later removed by the canonicalizer pass)