### PR TITLE
Optimise slice and pad

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   apply-formatting:
     if: ${{ github.event.issue.pull_request }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Clone git repo
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9.0]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9.0]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -168,7 +168,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9.0]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,10 +19,10 @@ env:
 jobs:
   macos-release-wheel:
     name: Build and test release wheels for macOS
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
-        python-version: [3.9.0]
+        python-version: [3.9]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -87,10 +87,10 @@ jobs:
 
   manylinux-release-wheel:
     name: Build and test release wheels for manylinux2014
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.9.0]
+        python-version: [3.9]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -168,7 +168,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: [3.9.0]
+        python-version: [3.9]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-xcore-archive.yml
+++ b/.github/workflows/build-xcore-archive.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build-release-archive:
     name: Build release archive
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9.0]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9.0]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9.0]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -257,7 +257,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9.0]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build-release-archive:
     name: Build release archive
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,10 +51,10 @@ jobs:
     if: github.event.pull_request.merged == true
     name: Build release wheels for macOS
     needs: [build-release-archive]
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
-        python-version: [3.9.0]
+        python-version: [3.9]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        python-version: [3.9.0]
+        python-version: [3.9]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -175,10 +175,10 @@ jobs:
     if: github.event.pull_request.merged == true
     name: Build release wheels for manylinux2014
     needs: [build-release-archive]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.9.0]
+        python-version: [3.9]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -257,7 +257,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: [3.9.0]
+        python-version: [3.9]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -326,7 +326,7 @@ jobs:
     if: github.event.pull_request.merged == true
     name: Publish wheels to PyPi
     needs: [macos-release-wheel, macos-arm-release-wheel, manylinux-release-wheel, windows-release-wheel]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   build-release-archive:
     name: Build release archive
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -59,10 +59,10 @@ jobs:
   macos-release-wheel:
     name: Build release wheels for macOS
     needs: [build-release-archive]
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       matrix:
-        python-version: [3.9.0]
+        python-version: [3.9]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        python-version: [3.9.0]
+        python-version: [3.9]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -186,10 +186,10 @@ jobs:
   manylinux-release-wheel:
     name: Build release wheels for manylinux2014
     needs: [build-release-archive]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.9.0]
+        python-version: [3.9]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -271,7 +271,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: [3.9.0]
+        python-version: [3.9]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -343,7 +343,7 @@ jobs:
     name: Publish wheels to PyPi
     if: ${{ always() }}
     needs: [macos-release-wheel, macos-arm-release-wheel, manylinux-release-wheel, windows-release-wheel]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9.0]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9.0]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -189,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9.0]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -271,7 +271,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9.0]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/xformer/Test/padding.mlir
+++ b/xformer/Test/padding.mlir
@@ -35,7 +35,7 @@ func.func @replace_pad_with_invalid_shape(%arg0: tensor<1x4x48x!quant.uniform<i8
 // CHECK-LABEL: replace_pad_with_batchchannel_padding
 func.func @replace_pad_with_batchchannel_padding(%arg0: tensor<1x4x1x48x!quant.uniform<i8:f32, 0.0078384801745414734:-1>>) -> tensor<1x4x3x48x!quant.uniform<i8:f32, 0.0078384801745414734:-1>> attributes {tf.entry_function = {inputs = "zero_padding2d_input_int8", outputs = "Identity_int8"}} {
   %0 = "tfl.pseudo_const"() {value = dense<[[1, 1], [0, 0], [2, 0], [1, 1]]> : tensor<4x2xi32>} : () -> tensor<4x2xi32>
-  // CHECK-NOT: xc.pad
+  // CHECK: xc.pad
   %1 = "tfl.pad"(%arg0, %0) : (tensor<1x4x1x48x!quant.uniform<i8:f32, 0.0078384801745414734:-1>>, tensor<4x2xi32>) -> tensor<1x4x3x48x!quant.uniform<i8:f32, 0.0078384801745414734:-1>>
   return %1 : tensor<1x4x3x48x!quant.uniform<i8:f32, 0.0078384801745414734:-1>>
 }

--- a/xformer/Transforms/ReplacePad.cpp
+++ b/xformer/Transforms/ReplacePad.cpp
@@ -57,12 +57,36 @@ struct ReplacePadPattern : public OpRewritePattern<TFL::PadOp> {
       return failure();
     }
 
+    DenseElementsAttr paddingAttr;
+    matchPattern(padOp.getPadding(), m_Constant(&paddingAttr));
+    auto paddingValues = paddingAttr.getValues<int32_t>();
+
+    std::vector<int32_t> paddingValuesStart;
+    std::vector<int32_t> paddingValuesEnd;
+    for (int i = 0; i < paddingValues.size(); i += 2)
+      paddingValuesStart.push_back(paddingValues[i]);
+    for (int i = 1; i < paddingValues.size(); i += 2)
+      paddingValuesEnd.push_back(paddingValues[i]);
+    auto inputShape = inputType.getShape();
+    auto outputShape = outputType.getShape();
+    std::vector<int32_t> inShapeVec(inputShape.begin(), inputShape.end());
+    std::vector<int32_t> outShapeVec(outputShape.begin(), outputShape.end());
+
+    // Assuming we can translate the pad op to reshape -> pad -> reshape
+    // such that the number of dimensions of the pad in the middle is as small
+    // as possible, rank would represent that number of dimensions.
+    int rank = utils::mergeAxes(paddingValuesStart, paddingValuesEnd,
+                                inShapeVec, outShapeVec, inputType.getRank());
+
+    if (rank > 2)
+      return failure();
+
     Type elementType = inputType.getElementType();
     const size_t dtype_size = utils::getTypeSize(elementType);
-    const int rank = inputType.getRank();
-
-    if (rank != 4)
-      return failure();
+    paddingValuesStart[rank - 1] *= dtype_size;
+    paddingValuesEnd[rank - 1] *= dtype_size;
+    outShapeVec[rank - 1] *= dtype_size;
+    inShapeVec[rank - 1] *= dtype_size;
 
     int32_t zero_point = 0;
     if (elementType.isa<quant::QuantizedType>()) {
@@ -70,56 +94,22 @@ struct ReplacePadPattern : public OpRewritePattern<TFL::PadOp> {
       zero_point = BROADCAST_8_TO_32(inputQType.getZeroPoint());
     }
 
-    DenseElementsAttr paddingAttr;
-    matchPattern(padOp.getPadding(), m_Constant(&paddingAttr));
-    auto paddingValues = paddingAttr.getValues<int32_t>();
-
-    if (paddingValues[0] != 0 || paddingValues[1] != 0)
-      return failure();
-
-    bool paddingHW = false;
-    for (int i = 2; i < 6; i++)
-      if (paddingValues[i] != 0)
-        paddingHW = true;
-    if (paddingHW && (paddingValues[6] != 0 || paddingValues[7] != 0))
-      return failure();
-
-    bool isNoOp = true;
-    for (int i = 0; i < 8; i++)
-      if (paddingValues[i] != 0)
-        isNoOp = false;
-
-    if (isNoOp) {
-      rewriter.replaceOp(padOp, padOp.getInput());
-      return success();
-    }
-
-    auto inShape = inputType.getShape();
-    auto outShape = outputType.getShape();
-
     int32_t start, pad_size, size, num_copies, end;
-    const int mulW = inShape[3] * dtype_size;
-    if (paddingHW) {
-      if (outShape[0] != 1)
-        return failure();
-      size = inShape[2] * mulW;
-      pad_size = (outShape[2] - inShape[2]) * mulW;
-      start = (paddingValues[2] * outShape[2] + paddingValues[4]) * mulW;
-      end = (paddingValues[3] * outShape[2] + paddingValues[5]) * mulW;
-      // -1 because the last memcpy is done separately, since we also need to
-      // memset
-      num_copies = inShape[1] - 1;
+    if (rank == 1) {
+      start = paddingValuesStart[0];
+      pad_size = 0;
+      size = inShapeVec[0];
+      num_copies = 0;
+      end = paddingValuesEnd[0];
     } else {
-      // Pad3to4 is a special case, handled by it's own op
-      if (inShape[3] == 3 && outShape[3] == 4)
+      // We have a special optimised Pad3to4 op for this case
+      if ((inShapeVec[1] == 3) && (outShapeVec[1] == 4))
         return failure();
-      size = mulW;
-      pad_size = (outShape[3] - inShape[3]) * dtype_size;
-      start = paddingValues[6] * dtype_size;
-      end = paddingValues[7] * dtype_size;
-      // -1 because the last memcpy is done separately, since we also need to
-      // memset
-      num_copies = inShape[2] * inShape[1] * inShape[0] - 1;
+      start = paddingValuesStart[0] * outShapeVec[1] + paddingValuesStart[1];
+      pad_size = paddingValuesStart[1] + paddingValuesEnd[1];
+      size = inShapeVec[1];
+      num_copies = inShapeVec[0] - 1;
+      end = paddingValuesEnd[0] * outShapeVec[1] + paddingValuesEnd[1];
     }
     bool isVpu =
         start % 4 == 0 && pad_size % 4 == 0 && size % 4 == 0 && end % 4 == 0;

--- a/xformer/Transforms/ReplaceSlice.cpp
+++ b/xformer/Transforms/ReplaceSlice.cpp
@@ -73,8 +73,8 @@ struct ReplaceSlicePattern : public OpRewritePattern<TFL::SliceOp> {
     std::vector<int32_t> inShapeVec(inShape.begin(), inShape.end());
     std::vector<int32_t> outShapeVec(outShape.begin(), outShape.end());
 
-    // Assuming we can translate the pad op to reshape -> pad -> reshape
-    // such that the number of dimensions of the pad in the middle is as small
+    // Assuming we can translate the slice op to reshape -> slice -> reshape
+    // such that the number of dimensions of the slice in the middle is as small
     // as possible, rank would represent that number of dimensions.
     int rank = utils::mergeAxes(begin, sizes, inShapeVec, outShapeVec,
                                 inputType.getRank());

--- a/xformer/Transforms/ReplaceSlice.cpp
+++ b/xformer/Transforms/ReplaceSlice.cpp
@@ -31,6 +31,35 @@ struct ReplaceSlice
   void runOnOperation() override;
 };
 
+int mergeAxes(std::vector<int32_t> &begin, std::vector<int32_t> &size,
+              std::vector<int32_t> &inShape, std::vector<int32_t> &outShape,
+              int rank) {
+
+  for (int i = rank - 1; i > 0; i--) {
+    while ((inShape[i] == outShape[i]) && (i > 0)) {
+      const int mul = inShape[i];
+      inShape[i - 1] *= mul;
+      outShape[i - 1] *= mul;
+      begin[i - 1] *= mul;
+      size[i - 1] *= mul;
+      inShape.erase(inShape.begin() + i);
+      outShape.erase(outShape.begin() + i);
+      begin.erase(begin.begin() + i);
+      size.erase(size.begin() + i);
+      rank -= 1;
+      i -= 1;
+    }
+  }
+  if ((inShape[0] == 1) && (outShape[0] == 1)) {
+    inShape.erase(inShape.begin());
+    outShape.erase(outShape.begin());
+    begin.erase(begin.begin());
+    size.erase(size.begin());
+    rank -= 1;
+  }
+  return rank;
+}
+
 struct ReplaceSlicePattern : public OpRewritePattern<TFL::SliceOp> {
   using OpRewritePattern<TFL::SliceOp>::OpRewritePattern;
 
@@ -65,37 +94,39 @@ struct ReplaceSlicePattern : public OpRewritePattern<TFL::SliceOp> {
     matchPattern(sliceOp.getSize(), m_Constant(&sizeAttr));
     auto sizeValues = sizeAttr.getValues<int32_t>();
 
-    const int rank = inputType.getRank();
-
-    if (rank != 4)
-      return failure();
-
     auto inShape = inputType.getShape();
     auto outShape = outputType.getShape();
 
-    const size_t dtype_size = utils::getTypeSize(inputElementType);
+    std::vector<int32_t> begin(beginValues.begin(), beginValues.end());
+    std::vector<int32_t> sizes(sizeValues.begin(), sizeValues.end());
+    std::vector<int32_t> inShapeVec(inShape.begin(), inShape.end());
+    std::vector<int32_t> outShapeVec(outShape.begin(), outShape.end());
 
-    int32_t start, offset, size, num_copies;
-    const int mulW = inShape[3] * dtype_size;
+    int rank =
+        mergeAxes(begin, sizes, inShapeVec, outShapeVec, inputType.getRank());
 
-    bool slicingHW = (inShape[2] != outShape[2]) || (inShape[1] != outShape[1]);
-
-    if (slicingHW && (outShape[3] != inShape[3]))
+    if (rank > 2)
       return failure();
 
-    if (slicingHW) {
-      if (inShape[0] != 1 || outShape[0] != 1)
-        return failure();
-      size = outShape[2] * mulW;
-      offset = inShape[2] * mulW;
-      start = beginValues[1] * offset + beginValues[2] * mulW;
-      num_copies = outShape[1];
+    const size_t dtype_size = utils::getTypeSize(inputElementType);
+    begin[rank - 1] *= dtype_size;
+    sizes[rank - 1] *= dtype_size;
+    inShapeVec[rank - 1] *= dtype_size;
+    outShapeVec[rank - 1] *= dtype_size;
+
+    int32_t start, offset, size, num_copies;
+    if (rank == 1) {
+      start = begin[0];
+      offset = inShapeVec[0];
+      size = outShapeVec[0];
+      num_copies = 1;
     } else {
-      offset = mulW;
-      size = outShape[3] * dtype_size;
-      start = beginValues[3] * dtype_size;
-      num_copies = outShape[0] * outputType.getShape()[1] * outShape[2];
+      start = begin[0] * inShapeVec[1] + begin[1];
+      offset = inShapeVec[1];
+      size = outShapeVec[1];
+      num_copies = outShapeVec[0];
     }
+
     bool isVpu = start % 4 == 0 && size % 4 == 0 && offset % 4 == 0;
     auto binaryObjectSliceOp = rewriter.create<SliceOp>(
         sliceOp.getLoc(), sliceOp.getType(), sliceOp.getInput(),

--- a/xformer/Utils/Util.cpp
+++ b/xformer/Utils/Util.cpp
@@ -96,4 +96,34 @@ bool checkSliceNoOp(RankedTensorType inputType, RankedTensorType outputType) {
   }
   return isNoOp;
 }
+
+int mergeAxes(std::vector<int32_t> &begin, std::vector<int32_t> &size,
+              std::vector<int32_t> &inShape, std::vector<int32_t> &outShape,
+              int rank) {
+
+  for (int i = rank - 1; i > 0; i--) {
+    while ((inShape[i] == outShape[i]) && (i > 0)) {
+      const int mul = inShape[i];
+      inShape[i - 1] *= mul;
+      outShape[i - 1] *= mul;
+      begin[i - 1] *= mul;
+      size[i - 1] *= mul;
+      inShape.erase(inShape.begin() + i);
+      outShape.erase(outShape.begin() + i);
+      begin.erase(begin.begin() + i);
+      size.erase(size.begin() + i);
+      rank -= 1;
+      i -= 1;
+    }
+  }
+  if ((inShape[0] == 1) && (outShape[0] == 1)) {
+    inShape.erase(inShape.begin());
+    outShape.erase(outShape.begin());
+    begin.erase(begin.begin());
+    size.erase(size.begin());
+    rank -= 1;
+  }
+  return rank;
+}
+
 } // namespace mlir::xcore::utils

--- a/xformer/Utils/Util.cpp
+++ b/xformer/Utils/Util.cpp
@@ -84,4 +84,16 @@ Type getValElementType(Value tensor) {
 ArrayRef<int64_t> getValShape(Value tensor) {
   return tensor.getType().template cast<RankedTensorType>().getShape();
 }
+
+bool checkSliceNoOp(RankedTensorType inputType, RankedTensorType outputType) {
+  const int rank = inputType.getRank();
+  bool isNoOp = true;
+  for (int i = 0; i < rank; i++) {
+    if (inputType.getDimSize(i) != outputType.getDimSize(i)) {
+      isNoOp = false;
+      break;
+    }
+  }
+  return isNoOp;
+}
 } // namespace mlir::xcore::utils

--- a/xformer/Utils/Util.h
+++ b/xformer/Utils/Util.h
@@ -17,18 +17,8 @@ bool hasOnlyChannelPadding(DenseIntElementsAttr attr);
 bool hasOnlySpatialPadding(DenseIntElementsAttr attr);
 
 quant::UniformQuantizedType getQType(mlir::TypedValue<mlir::TensorType> tensor);
-template <typename T>
-bool checkSliceNoOp(T beginValues, T sizeValues, RankedTensorType type) {
-  const int rank = type.getRank();
-  bool isNoOp = true;
-  for (int i = 0; i < rank; i++) {
-    if (beginValues[i] != 0 || sizeValues[i] != type.getShape()[i]) {
-      isNoOp = false;
-      break;
-    }
-  }
-  return isNoOp;
-}
+
+bool checkSliceNoOp(RankedTensorType inputType, RankedTensorType outputType);
 
 template <int N = 8> bool hasNBitSignedQType(Type type) {
   return (type.template isa<quant::QuantizedType>() &&

--- a/xformer/Utils/Util.h
+++ b/xformer/Utils/Util.h
@@ -63,6 +63,10 @@ template <typename T> bool checkBinaryCompatibility(T op) {
   }
   return true;
 }
+
+int mergeAxes(std::vector<int32_t> &begin, std::vector<int32_t> &size,
+              std::vector<int32_t> &inShape, std::vector<int32_t> &outShape,
+              int rank);
 } // namespace mlir::xcore::utils
 
 #endif // XFORMER_UTILS_UTIL_H

--- a/xformer/patches/flatbuffer_export.patch
+++ b/xformer/patches/flatbuffer_export.patch
@@ -1,5 +1,5 @@
 diff --git a/tensorflow/compiler/mlir/lite/flatbuffer_export.cc b/tensorflow/compiler/mlir/lite/flatbuffer_export.cc
-index 1a55e517791..445224147da 100644
+index 1a55e517791..cb2c21c8861 100644
 --- a/tensorflow/compiler/mlir/lite/flatbuffer_export.cc
 +++ b/tensorflow/compiler/mlir/lite/flatbuffer_export.cc
 @@ -244,6 +244,14 @@ static bool IsConst(Operation* op) {
@@ -44,3 +44,12 @@ index 1a55e517791..445224147da 100644
      metadata.push_back(BuildMetadata(kv.first, value));
    }
  
+@@ -2986,8 +2999,6 @@ std::optional<std::string> Translator::TranslateInternal() {
+       mac_str = absl::StrFormat("%.3f G ",
+                                 static_cast<double>(ops_count / 2) / billion);
+     }
+-    LOG(INFO) << "Estimated count of arithmetic ops: " << flops_str
+-              << " ops, equivalently " << mac_str << " MACs";
+   }
+ 
+   std::string model_description;


### PR DESCRIPTION
Generic compiler optimisation to handle all slices and pads that are supported in the runtime. Both ops should now handle any rank, as long the op can be translated to reshape -> slice/pad -> reshape with the rank of the tensor after the first reshape <= 2.

This should also make some ops that were already replaced slightly faster (slices/pads only along axis 1, for example)