### PR TITLE
Merge transposes

### DIFF
--- a/python/xmos_ai_tools/xinterpreters/host_interpreter.py
+++ b/python/xmos_ai_tools/xinterpreters/host_interpreter.py
@@ -242,7 +242,6 @@ class TFLMHostInterpreter:
         if self.obj:
             lib.delete_interpreter(self.obj)
             self.obj = None
-            print(self.obj)
 
     def tensor_arena_size(self) -> int:
         """! Read the size of the tensor arena required.

--- a/xformer/Transforms/OptimizeConv2D.cpp
+++ b/xformer/Transforms/OptimizeConv2D.cpp
@@ -86,6 +86,9 @@ struct ChannelwiseSplitConv2DOutputPattern
       return splitResultType;
     };
 
+    if(!llvm::isa<TFL::QConstOp>(op.getFilter().getDefiningOp()))
+      return failure();
+
     auto filterQConstOp =
         dyn_cast<TFL::QConstOp>(op.getFilter().getDefiningOp());
     auto filterType = op.getFilter().getType().cast<ShapedType>();

--- a/xformer/Transforms/OptimizeTranspose.cpp
+++ b/xformer/Transforms/OptimizeTranspose.cpp
@@ -104,7 +104,7 @@ struct MoveTransposeForwardOverUnaryOpPattern
 
     // Create a new Transpose operation after the unary operation
     auto newTransposeOp = rewriter.create<TFL::TransposeOp>(
-        transposeOp.getLoc(), transposeOutputType, newUnaryOpResult, perm);
+        transposeOp.getLoc(), newUnaryOutputType, newUnaryOpResult, perm);
 
     // Replace the original user operation's result with the new transpose
     // result

--- a/xformer/Transforms/OptimizeTranspose.cpp
+++ b/xformer/Transforms/OptimizeTranspose.cpp
@@ -3,6 +3,7 @@
 
 #include "Transforms/Options.h"
 
+#include "Utils/Util.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "tensorflow/compiler/mlir/lite/ir/tfl_ops.h"
@@ -58,6 +59,12 @@ struct FoldTransposeIntoFullyConnectedPattern
     // unchanged
     auto fcOutputShape = fcOutputType.getShape();
     auto reshapeOutputShape = reshapeOutputType.getShape();
+    SmallVector<int64_t, 4> reshapeOutputShapeVec(reshapeOutputShape.begin(),
+                                                  reshapeOutputShape.end());
+
+    if (reshapeOutputShape[0] != 1) {
+      return failure();
+    }
 
     if (fcOutputShape.empty() || reshapeOutputShape.empty())
       return failure(); // Expecting non-scalar tensors
@@ -79,10 +86,6 @@ struct FoldTransposeIntoFullyConnectedPattern
     if (permVec.empty() || permVec[0] != 0)
       return failure();
 
-    // Exclude the batch dimension from permVec
-    SmallVector<int64_t, 4> permVecExclBatch(permVec.begin() + 1,
-                                             permVec.end());
-
     // Prepare to transform the filter and bias
     Value filter = fullyConnectedOp.getFilter();
     Value bias = fullyConnectedOp.getBias();
@@ -100,67 +103,15 @@ struct FoldTransposeIntoFullyConnectedPattern
         return failure();
       auto biasShape = biasType.getShape();
 
-      // Get reshape output shape excluding batch dimension
-      SmallVector<int64_t, 4> reshapeShapeExclBatch(
-          reshapeOutputShape.begin() + 1, reshapeOutputShape.end());
-
-      // Compute total number of elements
-      int64_t biasNumElements = biasType.getNumElements();
-      int64_t reshapeNumElements = std::accumulate(
-          reshapeShapeExclBatch.begin(), reshapeShapeExclBatch.end(), 1,
-          std::multiplies<int64_t>());
-
-      if (biasNumElements != reshapeNumElements)
+      SmallVector<int64_t, 4> biasShapeVec(biasShape.begin(), biasShape.end());
+      Value finalBias;
+      if (failed(utils::reshapeTransposeReshape(rewriter, bias,
+                                                reshapeOutputShapeVec, permVec,
+                                                biasShapeVec, finalBias)))
         return failure();
 
-      // Reshape bias to match reshape output shape (excluding batch dimension)
-      auto newShapeType = RankedTensorType::get(
-          {static_cast<int64_t>(reshapeShapeExclBatch.size())},
-          rewriter.getI32Type());
-      auto newShapeAttr = DenseIntElementsAttr::get(
-          newShapeType, llvm::makeArrayRef(reshapeShapeExclBatch));
-      auto newShapeOp = rewriter.create<arith::ConstantOp>(
-          bias.getLoc(), newShapeType, newShapeAttr);
-
-      auto reshapedBiasType = RankedTensorType::get(reshapeShapeExclBatch,
-                                                    biasType.getElementType());
-      auto reshapedBias = rewriter.create<TFL::ReshapeOp>(
-          bias.getLoc(), reshapedBiasType, bias, newShapeOp);
-
-      // Create perm vector excluding batch dimension
-      auto permType =
-          RankedTensorType::get({static_cast<int64_t>(permVecExclBatch.size())},
-                                rewriter.getI32Type());
-      auto permAttr = DenseIntElementsAttr::get(
-          permType, llvm::makeArrayRef(permVecExclBatch));
-      auto permOp = rewriter.create<arith::ConstantOp>(transposeOp.getLoc(),
-                                                       permType, permAttr);
-
-      // Compute transposed shape
-      SmallVector<int64_t, 4> transposedShape;
-      for (auto idx : permVecExclBatch) {
-        transposedShape.push_back(reshapeShapeExclBatch[idx]);
-      }
-      auto transposedBiasType =
-          RankedTensorType::get(transposedShape, biasType.getElementType());
-
-      // Transpose the reshaped bias
-      auto transposedBias = rewriter.create<TFL::TransposeOp>(
-          bias.getLoc(), transposedBiasType, reshapedBias, permOp);
-
-      // Reshape back to original bias shape
-      auto origBiasShapeType = RankedTensorType::get(
-          {static_cast<int64_t>(biasShape.size())}, rewriter.getI32Type());
-      auto origBiasShapeAttr = DenseIntElementsAttr::get(
-          origBiasShapeType, llvm::makeArrayRef(biasShape));
-      auto origBiasShapeConst = rewriter.create<arith::ConstantOp>(
-          bias.getLoc(), origBiasShapeType, origBiasShapeAttr);
-
-      auto finalBias = rewriter.create<TFL::ReshapeOp>(
-          bias.getLoc(), biasType, transposedBias, origBiasShapeConst);
-
       // Update bias
-      bias = finalBias.getResult();
+      bias = finalBias;
     }
 
     // Process filter
@@ -175,102 +126,22 @@ struct FoldTransposeIntoFullyConnectedPattern
       if (!filterType)
         return failure();
       auto filterShape = filterType.getShape();
+      SmallVector<int64_t, 4> filterShapeVec(filterShape.begin(),
+                                             filterShape.end());
 
-      // Treat columns (first axis) as batch
-      SmallVector<int64_t, 4> filterShapeExclBatch(filterShape.begin() + 1,
-                                                   filterShape.end());
+      // same as the shape of the reshape, except for first dimension which
+      // should be the first dimension of the filterShape
+      SmallVector<int64_t, 4> filterOutShapeVec = {filterShape[1]};
+      filterOutShapeVec.insert(filterOutShapeVec.end(),
+                               reshapeOutputShapeVec.begin() + 1,
+                               reshapeOutputShapeVec.end());
 
-      // Get reshape output shape excluding batch dimension
-      SmallVector<int64_t, 4> reshapeShapeExclBatch(
-          reshapeOutputShape.begin() + 1, reshapeOutputShape.end());
-
-      // Compute total number of elements excluding batch dimension
-      int64_t filterNumElements = std::accumulate(filterShapeExclBatch.begin(),
-                                                  filterShapeExclBatch.end(), 1,
-                                                  std::multiplies<int64_t>());
-      int64_t reshapeNumElements = std::accumulate(
-          reshapeShapeExclBatch.begin(), reshapeShapeExclBatch.end(), 1,
-          std::multiplies<int64_t>());
-
-      if (filterNumElements != reshapeNumElements)
+      Value finalFilter;
+      if (failed(utils::reshapeTransposeReshape(rewriter, filter,
+                                                filterOutShapeVec, permVec,
+                                                filterShapeVec, finalFilter)))
         return failure();
-
-      // Reshape filter to match reshape output shape (excluding batch
-      // dimension)
-      auto newShapeType = RankedTensorType::get(
-          {static_cast<int64_t>(reshapeShapeExclBatch.size())},
-          rewriter.getI32Type());
-      auto newShapeAttr = DenseIntElementsAttr::get(
-          newShapeType, llvm::makeArrayRef(reshapeShapeExclBatch));
-      auto newShapeOp = rewriter.create<arith::ConstantOp>(
-          filter.getLoc(), newShapeType, newShapeAttr);
-
-      auto reshapedFilterType = RankedTensorType::get(
-          reshapeShapeExclBatch, filterType.getElementType());
-      auto reshapedFilter = rewriter.create<TFL::ReshapeOp>(
-          filter.getLoc(), reshapedFilterType, filter, newShapeOp);
-
-      // Create perm vector excluding batch dimension
-      auto permType =
-          RankedTensorType::get({static_cast<int64_t>(permVecExclBatch.size())},
-                                rewriter.getI32Type());
-      auto permAttr = DenseIntElementsAttr::get(
-          permType, llvm::makeArrayRef(permVecExclBatch));
-      auto permOp = rewriter.create<arith::ConstantOp>(transposeOp.getLoc(),
-                                                       permType, permAttr);
-
-      // Compute transposed shape
-      SmallVector<int64_t, 4> transposedShape;
-      for (auto idx : permVecExclBatch) {
-        transposedShape.push_back(reshapeShapeExclBatch[idx]);
-      }
-      auto transposedFilterType =
-          RankedTensorType::get(transposedShape, filterType.getElementType());
-
-      // Transpose the reshaped filter
-      auto transposedFilter = rewriter.create<TFL::TransposeOp>(
-          filter.getLoc(), transposedFilterType, reshapedFilter, permOp);
-
-      // Reshape back to original filter shape
-      SmallVector<int64_t, 4> origFilterShapeExclBatch(filterShape.begin() + 1,
-                                                       filterShape.end());
-      auto origFilterShapeType = RankedTensorType::get(
-          {static_cast<int64_t>(origFilterShapeExclBatch.size())},
-          rewriter.getI32Type());
-      auto origFilterShapeAttr = DenseIntElementsAttr::get(
-          origFilterShapeType, llvm::makeArrayRef(origFilterShapeExclBatch));
-      auto origFilterShapeConst = rewriter.create<arith::ConstantOp>(
-          filter.getLoc(), origFilterShapeType, origFilterShapeAttr);
-
-      // Reshape back to original filter shape (excluding batch dimension)
-      auto finalFilterType = RankedTensorType::get(filterShapeExclBatch,
-                                                   filterType.getElementType());
-      auto finalFilter = rewriter.create<TFL::ReshapeOp>(
-          filter.getLoc(), finalFilterType, transposedFilter,
-          origFilterShapeConst);
-
-      // Prepend the batch dimension back to the filter shape
-      SmallVector<int64_t, 4> newFilterShape;
-      newFilterShape.push_back(filterShape[0]); // Batch dimension
-      newFilterShape.append(filterShapeExclBatch.begin(),
-                            filterShapeExclBatch.end());
-
-      auto newFilterType =
-          RankedTensorType::get(newFilterShape, filterType.getElementType());
-
-      // Create a reshape to get back to the original filter shape
-      auto finalFilterShapeType = RankedTensorType::get(
-          {static_cast<int64_t>(newFilterShape.size())}, rewriter.getI32Type());
-      auto finalFilterShapeAttr = DenseIntElementsAttr::get(
-          finalFilterShapeType, llvm::makeArrayRef(newFilterShape));
-      auto finalFilterShapeConst = rewriter.create<arith::ConstantOp>(
-          filter.getLoc(), finalFilterShapeType, finalFilterShapeAttr);
-
-      auto finalFilterReshaped = rewriter.create<TFL::ReshapeOp>(
-          filter.getLoc(), filterType, finalFilter, finalFilterShapeConst);
-
-      // Update filter
-      filter = finalFilterReshaped.getResult();
+      filter = finalFilter;
     }
 
     // Create new fully connected op with adjusted filter and bias
@@ -281,10 +152,18 @@ struct FoldTransposeIntoFullyConnectedPattern
         fullyConnectedOp.getKeepNumDimsAttr(),
         fullyConnectedOp.getAsymmetricQuantizeInputsAttr());
 
+    // create new shape from the shape of the original transpose op
+    auto originalShape =
+        transposeOp.getResult().getType().cast<RankedTensorType>().getShape();
+    SmallVector<int64_t, 4> originalShapeVec(originalShape.begin(),
+                                             originalShape.end());
+    Value newShapeConstOp = utils::createShapeConstOp(
+        rewriter, transposeOp.getLoc(), originalShapeVec);
+
     // Create new reshape op with the output type of the original transpose op
     auto newReshapeOp = rewriter.create<TFL::ReshapeOp>(
         reshapeOp.getLoc(), transposeOutputType,
-        newFullyConnectedOp.getResult(0), reshapeOp.getShape());
+        newFullyConnectedOp.getResult(0), newShapeConstOp);
 
     // Replace the original transpose op with the new reshape op
     rewriter.replaceOp(transposeOp, newReshapeOp.getResult());

--- a/xformer/Transforms/OptimizeTranspose.cpp
+++ b/xformer/Transforms/OptimizeTranspose.cpp
@@ -1,7 +1,6 @@
 // Copyright 2023 XMOS LIMITED. This Software is subject to the terms of the
 // XMOS Public License: Version 1
 
-#include "IR/XCoreOps.h"
 #include "Transforms/Options.h"
 
 #include "mlir/Pass/Pass.h"
@@ -25,105 +24,322 @@ struct OptimizeTranspose
   void runOnOperation() override;
 };
 
-struct HoistTransposeWCHAbovePadPattern
+struct MoveTransposeForwardOverUnaryOpPattern
+    : public OpRewritePattern<TFL::TransposeOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(TFL::TransposeOp transposeOp,
+                                PatternRewriter &rewriter) const override {
+    // Ensure the TransposeOp has a single use
+    if (!transposeOp->hasOneUse())
+      return failure();
+
+    Operation *userOp = *transposeOp->getUsers().begin();
+
+    // Check if the user operation is a unary op that can commute with transpose
+    if (!isa<TFL::AbsOp, TFL::NegOp, TFL::ReluOp, TFL::Relu6Op, TFL::QuantizeOp,
+             TFL::LeakyReluOp, TFL::TanhOp, TFL::LogisticOp>(userOp))
+      return failure();
+
+    // Get the types of the input and output tensors
+    auto transposeInputType =
+        transposeOp.getInput().getType().dyn_cast<RankedTensorType>();
+    auto transposeOutputType =
+        transposeOp.getType().dyn_cast<RankedTensorType>();
+    if (!transposeInputType || !transposeOutputType)
+      return failure();
+
+    // Get the permutation used in the transpose
+    Value perm = transposeOp.getPerm();
+
+    Value newUnaryOpResult;
+    auto loc = userOp->getLoc();
+    auto input = transposeOp.getInput();
+
+    // Retrieve the original unary operation's output type
+    auto originalUnaryOutputType =
+        userOp->getResult(0).getType().dyn_cast<RankedTensorType>();
+    if (!originalUnaryOutputType)
+      return failure();
+
+    // Create a new output type for the unary op with the same shape as 'input'
+    // and the same element type as the original output type
+    auto newUnaryOutputType = RankedTensorType::get(
+        transposeInputType.getShape(), originalUnaryOutputType.getElementType(),
+        originalUnaryOutputType.getEncoding());
+
+    if (auto quantizeOp = dyn_cast<TFL::QuantizeOp>(userOp)) {
+      // For QuantizeOp, create new QuantizeOp with input as 'input' and output
+      // type adjusted
+
+      // Create new QuantizeOp with adjusted output type
+      newUnaryOpResult = rewriter.create<TFL::QuantizeOp>(
+          loc, newUnaryOutputType, input, quantizeOp.getQtypeAttr());
+
+    } else if (auto absOp = dyn_cast<TFL::AbsOp>(userOp)) {
+      newUnaryOpResult =
+          rewriter.create<TFL::AbsOp>(loc, newUnaryOutputType, input);
+    } else if (auto negOp = dyn_cast<TFL::NegOp>(userOp)) {
+      newUnaryOpResult =
+          rewriter.create<TFL::NegOp>(loc, newUnaryOutputType, input);
+    } else if (auto reluOp = dyn_cast<TFL::ReluOp>(userOp)) {
+      newUnaryOpResult =
+          rewriter.create<TFL::ReluOp>(loc, newUnaryOutputType, input);
+    } else if (auto relu6Op = dyn_cast<TFL::Relu6Op>(userOp)) {
+      newUnaryOpResult =
+          rewriter.create<TFL::Relu6Op>(loc, newUnaryOutputType, input);
+    } else if (auto leakyReluOp = dyn_cast<TFL::LeakyReluOp>(userOp)) {
+      newUnaryOpResult = rewriter.create<TFL::LeakyReluOp>(
+          loc, newUnaryOutputType, input, leakyReluOp.getAlphaAttr());
+    } else if (auto tanhOp = dyn_cast<TFL::TanhOp>(userOp)) {
+      newUnaryOpResult =
+          rewriter.create<TFL::TanhOp>(loc, newUnaryOutputType, input);
+    } else if (auto logisticOp = dyn_cast<TFL::LogisticOp>(userOp)) {
+      newUnaryOpResult =
+          rewriter.create<TFL::LogisticOp>(loc, newUnaryOutputType, input);
+    } else {
+      // This should not happen as we checked the op type earlier
+      return failure();
+    }
+
+    // Create a new Transpose operation after the unary operation
+    auto newTransposeOp = rewriter.create<TFL::TransposeOp>(
+        transposeOp.getLoc(), transposeOutputType, newUnaryOpResult, perm);
+
+    // Replace the original user operation's result with the new transpose
+    // result
+    rewriter.replaceOp(userOp, newTransposeOp.getResult());
+
+    // Remove the original TransposeOp
+    rewriter.eraseOp(transposeOp);
+
+    return success();
+  }
+};
+
+struct MoveTransposeForwardOverConcatOpPattern
+    : public OpRewritePattern<TFL::ConcatenationOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(TFL::ConcatenationOp concatOp,
+                                PatternRewriter &rewriter) const override {
+    // Get all input operands
+    auto inputs = concatOp.getValues();
+
+    // Check that all inputs are TransposeOps with the same permutation
+    SmallVector<Value, 4> newInputs;
+    DenseIntElementsAttr commonPermAttr;
+    for (auto input : inputs) {
+      auto transposeOp = input.getDefiningOp<TFL::TransposeOp>();
+      if (!transposeOp)
+        return failure();
+
+      // Get permutation attribute
+      DenseIntElementsAttr permAttr;
+      if (!matchPattern(transposeOp.getPerm(), m_Constant(&permAttr)))
+        return failure();
+
+      // Check if the permutation is the same as others
+      if (commonPermAttr) {
+        if (permAttr != commonPermAttr)
+          return failure();
+      } else {
+        commonPermAttr = permAttr;
+      }
+
+      // Collect the inputs to the transpose ops
+      newInputs.push_back(transposeOp.getInput());
+    }
+
+    // Get the permutation vector
+    SmallVector<int32_t, 4> permVec;
+    for (auto val : commonPermAttr.getValues<int32_t>()) {
+      permVec.push_back(val);
+    }
+
+    // Compute the inverse permutation
+    SmallVector<int32_t, 4> invPerm(permVec.size());
+    for (size_t i = 0; i < permVec.size(); ++i) {
+      invPerm[permVec[i]] = i;
+    }
+
+    // Adjust the axis according to the inverse permutation
+    int32_t oldAxis = concatOp.getAxis();
+    int64_t rank = permVec.size();
+    if (oldAxis < 0) {
+      oldAxis += rank;
+    }
+    if (oldAxis < 0 || oldAxis >= rank) {
+      return failure(); // Invalid axis
+    }
+    int32_t newAxis = invPerm[oldAxis];
+
+    // Collect input types and compute the new result type
+    SmallVector<RankedTensorType, 4> inputTypes;
+    for (auto input : newInputs) {
+      auto inputType = input.getType().dyn_cast<RankedTensorType>();
+      if (!inputType) {
+        return failure();
+      }
+      inputTypes.push_back(inputType);
+    }
+
+    // Ensure all input types have the same rank
+    for (auto type : inputTypes) {
+      if (type.getRank() != rank) {
+        return failure();
+      }
+    }
+
+    // Compute the shape of the concatenated tensor
+    SmallVector<int64_t, 4> resultShape(inputTypes[0].getShape().begin(),
+                                        inputTypes[0].getShape().end());
+    for (size_t i = 1; i < inputTypes.size(); ++i) {
+      auto shape = inputTypes[i].getShape();
+      for (int64_t dim = 0; dim < rank; ++dim) {
+        if (dim == newAxis) {
+          resultShape[dim] += shape[dim];
+        } else if (resultShape[dim] != shape[dim]) {
+          // Dimensions must be equal except for the concatenation axis
+          return failure();
+        }
+      }
+    }
+
+    // Create the new ConcatenationOp with the correct result type and axis
+    auto elementType = inputTypes[0].getElementType();
+    auto newConcatType = RankedTensorType::get(resultShape, elementType);
+    auto newConcatOp = rewriter.create<TFL::ConcatenationOp>(
+        concatOp.getLoc(), newConcatType, newInputs,
+        rewriter.getI32IntegerAttr(newAxis),
+        concatOp.getFusedActivationFunctionAttr());
+
+    // Create the permutation constant with correct data types
+    auto permType = RankedTensorType::get(
+        {static_cast<int64_t>(permVec.size())}, rewriter.getIntegerType(32));
+    auto permAttr = DenseIntElementsAttr::get(permType, permVec);
+    auto permConstOp = rewriter.create<arith::ConstantOp>(concatOp.getLoc(),
+                                                          permType, permAttr);
+
+    // Create the new TransposeOp with the original output type
+    auto newTransposeOp = rewriter.create<TFL::TransposeOp>(
+        concatOp.getLoc(), concatOp.getType(), newConcatOp.getResult(),
+        permConstOp.getResult());
+
+    rewriter.replaceOp(concatOp, newTransposeOp.getResult());
+    return success();
+  }
+};
+
+struct HoistTransposeAbovePadPattern
     : public OpRewritePattern<TFL::TransposeOp> {
   using OpRewritePattern<TFL::TransposeOp>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(TFL::TransposeOp op,
                                 PatternRewriter &rewriter) const override {
-
-    // Check for invalid types and return
-    // Defining op must be pad
+    // Check if the input to TransposeOp is a PadOp
     auto padOp = dyn_cast_or_null<TFL::PadOp>(op.getInput().getDefiningOp());
     if (!padOp) {
       return failure();
     }
 
-    // Get transpose permutation
-    DenseIntElementsAttr perm;
-    if (!matchPattern(op.getPerm(), m_Constant(&perm))) {
+    // Get the permutation attribute
+    DenseIntElementsAttr permAttr;
+    if (!matchPattern(op.getPerm(), m_Constant(&permAttr))) {
       return failure();
     }
+    auto perm = permAttr.getValues<int32_t>();
 
-    // Confirm transpose permutation is 0,2,3,1 i.e., NWCH
-    // Remnants of Pytorch to TFlite conversion
-    auto permVal = perm.getValues<int32_t>();
-    if (perm.size() != 4 || permVal[0] != 0 || permVal[1] != 2 ||
-        permVal[2] != 3 || permVal[3] != 1) {
+    // Get the padding attribute
+    DenseIntElementsAttr padAttr;
+    if (!matchPattern(padOp.getPadding(), m_Constant(&padAttr))) {
       return failure();
     }
+    auto padValues = padAttr.getValues<int32_t>();
 
-    // Get padding val
-    DenseIntElementsAttr pad;
-    if (!matchPattern(padOp.getPadding(), m_Constant(&pad))) {
+    // Get the rank of the tensor
+    auto padInputType = padOp.getInput().getType().dyn_cast<RankedTensorType>();
+    if (!padInputType) {
       return failure();
     }
+    int64_t rank = padInputType.getRank();
 
-    // Confirm padding is only in last two dimensions
-    auto padVal = pad.getValues<int32_t>();
-    if (padVal[{0, 0}] != 0 || padVal[{0, 1}] != 0 || padVal[{1, 0}] != 0 ||
-        padVal[{1, 1}] != 0 || padVal[{2, 0}] != 1 || padVal[{2, 1}] != 1 ||
-        padVal[{3, 0}] != 1 || padVal[{3, 1}] != 1) {
-      return failure();
+    // Reshape the padding values into a matrix of shape [rank, 2]
+    SmallVector<int32_t, 8> paddingMatrix;
+    paddingMatrix.reserve(padValues.size());
+    for (int64_t i = 0; i < padValues.size(); ++i) {
+      paddingMatrix.push_back(padValues[i]);
     }
 
-    // Create new TransposeOp
-    auto padInputShape =
-        padOp.getInput().getType().cast<RankedTensorType>().getShape();
-    auto tranposeResultType = RankedTensorType::get(
-        {padInputShape[0], padInputShape[2], padInputShape[3],
-         padInputShape[1]},
-        padOp.getInput().getType().cast<ShapedType>().getElementType());
+    // Create a mapping from old dimensions to new dimensions after transpose
+    SmallVector<int32_t, 8> inversePerm(rank);
+    for (int64_t i = 0; i < rank; ++i) {
+      inversePerm[perm[i]] = i;
+    }
+
+    // Permute the padding according to the inverse permutation
+    SmallVector<int32_t, 8> newPaddingValues;
+    newPaddingValues.reserve(paddingMatrix.size());
+    for (int64_t i = 0; i < rank; ++i) {
+      int32_t dim = inversePerm[i];
+      newPaddingValues.push_back(paddingMatrix[dim * 2]);
+      newPaddingValues.push_back(paddingMatrix[dim * 2 + 1]);
+    }
+
+    // Create new TransposeOp before PadOp's input
+    auto newTransposeType = padOp.getInput().getType();
     auto newTranspose = rewriter.create<TFL::TransposeOp>(
-        padOp.getLoc(), tranposeResultType, padOp.getInput(), op.getPerm());
+        padOp.getLoc(), newTransposeType, padOp.getInput(), op.getPerm());
 
-    // Create new padding attr with spatial dimensions
-    std::vector<int32_t> paddingValues{0, 0, 1, 1, 1, 1, 0, 0};
-    auto paddingAttr = DenseIntElementsAttr::get(
-        RankedTensorType::get({4, 2}, rewriter.getI32Type()), paddingValues);
-    auto paddingOp = rewriter.create<arith::ConstantOp>(
-        padOp->getLoc(), RankedTensorType::get({4, 2}, rewriter.getI32Type()),
-        paddingAttr);
-    auto newPad = rewriter.create<TFL::PadOp>(
-        padOp.getLoc(), op.getOutput().getType(), newTranspose, paddingOp);
+    // Create new padding constant
+    auto newPaddingAttr = DenseIntElementsAttr::get(
+        RankedTensorType::get({rank, 2}, rewriter.getI32Type()),
+        newPaddingValues);
+    auto newPaddingConst = rewriter.create<arith::ConstantOp>(
+        padOp.getLoc(), newPaddingAttr.getType(), newPaddingAttr);
 
-    rewriter.replaceOp(op, newPad.getOutput());
+    // Create new PadOp after TransposeOp
+    auto newPadType = op.getType();
+    auto newPad = rewriter.create<TFL::PadOp>(padOp.getLoc(), newPadType,
+                                              newTranspose, newPaddingConst);
+
+    rewriter.replaceOp(op, newPad.getResult());
     return success();
   }
 };
+
 struct FoldCancellableTransposePattern
     : public OpRewritePattern<TFL::TransposeOp> {
   using OpRewritePattern<TFL::TransposeOp>::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(TFL::TransposeOp op,
+  LogicalResult matchAndRewrite(TFL::TransposeOp transposeOp,
                                 PatternRewriter &rewriter) const override {
 
-    // Check for invalid types and return
-    // Defining op must be transpose
-    auto transposeOp =
-        dyn_cast_or_null<TFL::TransposeOp>(op.getInput().getDefiningOp());
-    if (!transposeOp) {
+    auto inputTransposeOp =
+        transposeOp.getInput().getDefiningOp<TFL::TransposeOp>();
+    if (!inputTransposeOp)
       return failure();
-    }
 
-    // Get transpose permutations
-    DenseIntElementsAttr perm0;
-    DenseIntElementsAttr perm1;
-    if (!matchPattern(op.getPerm(), m_Constant(&perm0)) ||
-        !matchPattern(transposeOp.getPerm(), m_Constant(&perm1))) {
+    // Check if permutations are inverses
+    DenseIntElementsAttr perm1, perm2;
+    if (!matchPattern(transposeOp.getPerm(), m_Constant(&perm1)) ||
+        !matchPattern(inputTransposeOp.getPerm(), m_Constant(&perm2)))
       return failure();
-    }
 
-    // Do permutation indices cancel each other?
-    if (!TF::AreCancellablePermutations(perm0, perm1)) {
+    if (!TF::AreCancellablePermutations(perm1, perm2))
       return failure();
-    }
 
-    rewriter.replaceOp(op, transposeOp.getInput());
+    // Replace the outer transpose with the input of the inner transpose
+    rewriter.replaceOp(transposeOp, inputTransposeOp.getInput());
+
+    // Erase the inner transpose if it has no more uses
+    if (inputTransposeOp.use_empty())
+      rewriter.eraseOp(inputTransposeOp);
 
     return success();
   }
 };
+
 struct FoldTransposeWCHToInput : public OpRewritePattern<TFL::TransposeOp> {
   using OpRewritePattern<TFL::TransposeOp>::OpRewritePattern;
 
@@ -176,9 +392,20 @@ struct FoldTransposeWCHToInput : public OpRewritePattern<TFL::TransposeOp> {
 void OptimizeTranspose::runOnOperation() {
   auto *ctx = &getContext();
   func::FuncOp func = getOperation();
+
+  // Try to merge transpose -> ops -> inverse transpose
+  RewritePatternSet mergePatterns(ctx);
+  mergePatterns.insert<MoveTransposeForwardOverUnaryOpPattern,
+                       MoveTransposeForwardOverConcatOpPattern,
+                       FoldCancellableTransposePattern>(ctx);
+  if (mergeTransposeOption) {
+    (void)applyPatternsAndFoldGreedily(func, std::move(mergePatterns));
+  }
+
+  // Other transpose optimizations
   RewritePatternSet patterns(ctx);
 
-  patterns.insert<HoistTransposeWCHAbovePadPattern>(ctx);
+  patterns.insert<HoistTransposeAbovePadPattern>(ctx);
   patterns.insert<FoldCancellableTransposePattern>(ctx);
   if (allowInputModificationOption) {
     patterns.insert<FoldTransposeWCHToInput>(ctx);

--- a/xformer/Transforms/OptimizeTranspose.cpp
+++ b/xformer/Transforms/OptimizeTranspose.cpp
@@ -641,8 +641,9 @@ void OptimizeTranspose::runOnOperation() {
 
   patterns.insert<HoistTransposeWCHAbovePadPattern>(ctx);
   patterns.insert<FoldCancellableTransposePattern>(ctx);
-  patterns.insert<FoldFCReTrPattern>(ctx);
-  patterns.insert<FoldTrReFCPattern>(ctx);
+  // TODO - enable after transpose permutation fix
+  // patterns.insert<FoldFCReTrPattern>(ctx);
+  // patterns.insert<FoldTrReFCPattern>(ctx);
   if (allowInputModificationOption) {
     patterns.insert<FoldTransposeWCHToInput>(ctx);
   }

--- a/xformer/Transforms/Options.h
+++ b/xformer/Transforms/Options.h
@@ -26,6 +26,7 @@ extern llvm::cl::list<unsigned> opSplitBottomOpsOption;
 extern llvm::cl::list<unsigned> opSplitTopOpsOption;
 extern llvm::cl::list<unsigned> opSplitNumSplitsOption;
 extern llvm::cl::opt<bool> allowInputModificationOption;
+extern llvm::cl::opt<bool> mergeTransposeOption;
 extern llvm::cl::opt<bool> convDebugOption;
 extern llvm::cl::opt<bool> overlapConvOption;
 extern llvm::cl::opt<bool> offlineOffsetsOption;

--- a/xformer/Transforms/Passes.cpp
+++ b/xformer/Transforms/Passes.cpp
@@ -22,6 +22,8 @@ void buildXCorePreOpSplitPassPipeline(OpPassManager &pm) {
 void buildXCoreRemainingPassPipeline(OpPassManager &pm) {
   // TFL passes
   pm.addPass(createOptimizeTransposePass());
+  // Run canonicalization for constant folding Transpose, if any
+  pm.addPass(mlir::createCanonicalizerPass());
   pm.addPass(createReplaceAvgPoolWithConv2DPass());
   pm.addPass(createReplaceFCWithConv2DPass());
   if (opSplitTensorArenaOption) {

--- a/xformer/Utils/Util.cpp
+++ b/xformer/Utils/Util.cpp
@@ -2,7 +2,6 @@
 // XMOS Public License: Version 1
 
 #include "Utils/Util.h"
-#include <iostream>
 
 #include "mlir/Dialect/Quant/QuantTypes.h"
 #include "llvm/ADT/ArrayRef.h"

--- a/xformer/Utils/Util.cpp
+++ b/xformer/Utils/Util.cpp
@@ -216,4 +216,5 @@ reshapeTransposeReshape(PatternRewriter &rewriter, Value tensor,
   result = finalTensor.getResult();
   return success();
 }
+
 } // namespace mlir::xcore::utils

--- a/xformer/Utils/Util.h
+++ b/xformer/Utils/Util.h
@@ -7,6 +7,7 @@
 #include "mlir/Dialect/Quant/QuantTypes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "tensorflow/compiler/mlir/lite/ir/tfl_ops.h"
 
 namespace mlir::xcore::utils {
 
@@ -69,6 +70,19 @@ template <typename T> bool checkBinaryCompatibility(T op) {
 int mergeAxes(std::vector<int32_t> &begin, std::vector<int32_t> &size,
               std::vector<int32_t> &inShape, std::vector<int32_t> &outShape,
               int rank);
+
+LogicalResult convertToI32Array(const SmallVectorImpl<int64_t> &input,
+                                SmallVectorImpl<int32_t> &output);
+
+Value createShapeConstOp(PatternRewriter &rewriter, Location loc,
+                         const SmallVectorImpl<int64_t> &shapeVec);
+
+LogicalResult
+reshapeTransposeReshape(PatternRewriter &rewriter, Value tensor,
+                        const SmallVectorImpl<int64_t> &reshapeShape,
+                        const SmallVectorImpl<int64_t> &permVec,
+                        const SmallVectorImpl<int64_t> &origShape,
+                        Value &result);
 } // namespace mlir::xcore::utils
 
 #endif // XFORMER_UTILS_UTIL_H

--- a/xformer/Utils/Util.h
+++ b/xformer/Utils/Util.h
@@ -8,6 +8,7 @@
 #include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "tensorflow/compiler/mlir/lite/ir/tfl_ops.h"
+#include <cstdint>
 
 namespace mlir::xcore::utils {
 
@@ -83,6 +84,14 @@ reshapeTransposeReshape(PatternRewriter &rewriter, Value tensor,
                         const SmallVectorImpl<int64_t> &permVec,
                         const SmallVectorImpl<int64_t> &origShape,
                         Value &result);
+
+template <typename T = int64_t>
+static SmallVector<T, 4> denseToVector(DenseIntElementsAttr permAttr) {
+  SmallVector<T, 4> permVec;
+  for (auto val : permAttr.getValues<int32_t>())
+    permVec.push_back(static_cast<T>(val));
+  return permVec;
+}
 } // namespace mlir::xcore::utils
 
 #endif // XFORMER_UTILS_UTIL_H

--- a/xformer/XCoreOptMain.cpp
+++ b/xformer/XCoreOptMain.cpp
@@ -159,6 +159,11 @@ cl::opt<bool> allowInputModificationOption(
     cl::desc("Allow the compiler to modify input tensor for optimizations."),
     cl::init(false), cl::cat(XformerCategory), cl::Hidden);
 
+cl::opt<bool> mergeTransposeOption(
+    "xcore-merge-transpose",
+    cl::desc("Try to merge transpose and inverse transpose together."),
+    cl::init(true), cl::cat(XformerCategory), cl::Hidden);
+
 cl::opt<bool> convDebugOption("xcore-conv-debug",
                               cl::desc("Enable conv debug prints."),
                               cl::init(false), cl::cat(XformerCategory),


### PR DESCRIPTION
Merge transposes if they can be merged

Implementation (in a loop):
- Keep raising transpose above unary ops
- Keep raising transpose above concat ops
- Merge 2 equivalent transposes if possible

Potential improvements:
- Move over binary ops
- Move over slices
- Move over ops along an axis (like mean/max pools)
- After all of the above are done, find the best place to put remaining transposes
- Implement XC_transpose