### PR TITLE
Fixed condition checking when replacing MaxPool2DOp

### DIFF
--- a/xformer/Transforms/ReplaceMaxPool2D.cpp
+++ b/xformer/Transforms/ReplaceMaxPool2D.cpp
@@ -41,6 +41,10 @@ struct ReplaceMaxPool2DPattern : public OpRewritePattern<TFL::MaxPool2DOp> {
     auto outputHeight = outputType.getDimSize(1);
     auto outputWidth = outputType.getDimSize(2);
     auto outputDepth = outputType.getDimSize(3);
+    // Input depth must be multiple of four
+    if (inputDepth % 4 != 0) {
+      return failure();
+    }
     auto splits = utils::getImageRegionThreadSplits(
         threadCountOption, outputHeight, outputWidth, outputDepth);
 


### PR DESCRIPTION
The current code will replace all TFL_MaxPool2DOp to XC_MaxPool2DOp.
But the lib_nn implementation had the constraint of input depth needs to be multiple of 4.
This pull request added a condition checking that if the input depth is not multiple of 4, the TFL_MaxPool2DOp will not be converted to XC_MaxPool2DOp.