### PR TITLE
Bump to python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM tensorflow/build:2.15-python3.10
+FROM tensorflow/build:2.15-python3.11
 RUN pip install setuptools~=70.0 setuptools-scm

--- a/python/setup.py
+++ b/python/setup.py
@@ -103,6 +103,7 @@ setup(
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Mathematics",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-# python_version 3.9
-# pip_version 22.*
+# python_version 3.11
+# pip_version 25.*
 
 tensorflow==2.15.0; sys_platform != 'darwin' and platform_machine != 'arm64'
 tensorflow==2.11.0; sys_platform == 'darwin' and platform_machine == 'x86_64'


### PR DESCRIPTION
Bump to maintained version of Python (that has Tensorflow 2.15 wheels)

Python 3.11 is supported until October 2027