### PR TITLE
Added erase pattern for double redundant transpose ops

### DIFF
--- a/xformer/Transforms/OptimizeTranspose.cpp
+++ b/xformer/Transforms/OptimizeTranspose.cpp
@@ -182,6 +182,51 @@ struct FoldDoubleTransposePattern : public OpRewritePattern<TFL::TransposeOp> {
   }
 };
 
+// Erase Transpose and Inverse Transpose pair that the input dimension and output dimension are the same
+struct EraseDoubleTransposePattern : public OpRewritePattern<TFL::TransposeOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(TFL::TransposeOp transposeOp,
+                                PatternRewriter &rewriter) const override {
+    // Get the permutation used in the transposes
+    DenseIntElementsAttr perm0;
+    if (!matchPattern(transposeOp.getPerm(), m_Constant(&perm0)))
+      return failure();
+
+    SmallVector<Operation *> users(transposeOp->user_begin(), transposeOp->user_end());
+    for (Operation *userOp : users) {
+      // Check if the user operation is a transpose op
+      auto userTransposeOp = dyn_cast<TFL::TransposeOp>(userOp);
+      if (!userTransposeOp) {
+        return failure();
+      }
+
+      // Get the permutation used in the user transposes
+      DenseIntElementsAttr perm1;
+      if (!matchPattern(userTransposeOp.getPerm(), m_Constant(&perm1)))
+        return failure();
+
+      // Check if this is the inverse of parent transpose
+      int32_t correspondingDim = 0;
+      for (auto val : perm1.getValues<int32_t>()) {
+        if (correspondingDim != perm0.getValues<int32_t>()[val]) {
+          return failure();
+        }
+        correspondingDim += 1;
+      }
+    }
+
+    // Reaching this stage means all user ops are exact inverse transpose ops
+    // Removing all of them
+    for (Operation *userOp : users) {
+      auto userTransposeOp = dyn_cast<TFL::TransposeOp>(userOp);
+      rewriter.replaceAllUsesWith(userTransposeOp.getResult(), transposeOp.getInput());
+      rewriter.eraseOp(userOp);
+    }
+    rewriter.eraseOp(transposeOp);
+    return success();
+  }
+};
+
 // Replace TransposeOp with ReshapeOp if equivalent
 // Transpose is equivalent to reshape if we only permute consecutive dimensions
 // and only one of those permuted dimensions isn't of size 1
@@ -719,6 +764,12 @@ void OptimizeTranspose::runOnOperation() {
   }
 
   (void)applyPatternsAndFoldGreedily(func, std::move(patterns));
+
+  // Erase double transpose optimizations
+  RewritePatternSet erasePatterns(ctx);
+  erasePatterns.insert<EraseDoubleTransposePattern>(ctx);
+
+  (void)applyPatternsAndFoldGreedily(func, std::move(erasePatterns));
 }
 } // namespace
 

--- a/xformer/Transforms/OptimizeTranspose.cpp
+++ b/xformer/Transforms/OptimizeTranspose.cpp
@@ -187,43 +187,60 @@ struct EraseDoubleTransposePattern : public OpRewritePattern<TFL::TransposeOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(TFL::TransposeOp transposeOp,
                                 PatternRewriter &rewriter) const override {
+    bool IRModified = false;
     // Get the permutation used in the transposes
     DenseIntElementsAttr perm0;
-    if (!matchPattern(transposeOp.getPerm(), m_Constant(&perm0)))
+    if (!matchPattern(transposeOp.getPerm(), m_Constant(&perm0))) {
       return failure();
+    }
 
     SmallVector<Operation *> users(transposeOp->user_begin(), transposeOp->user_end());
+    bool allUserErased = true;
     for (Operation *userOp : users) {
       // Check if the user operation is a transpose op
       auto userTransposeOp = dyn_cast<TFL::TransposeOp>(userOp);
       if (!userTransposeOp) {
-        return failure();
+        allUserErased = false;
+        continue;
       }
 
       // Get the permutation used in the user transposes
       DenseIntElementsAttr perm1;
-      if (!matchPattern(userTransposeOp.getPerm(), m_Constant(&perm1)))
-        return failure();
+      if (!matchPattern(userTransposeOp.getPerm(), m_Constant(&perm1))) {
+        allUserErased = false;
+        continue;
+      }
 
       // Check if this is the inverse of parent transpose
       int32_t correspondingDim = 0;
+      bool userIsInverseTranspose = true;
       for (auto val : perm1.getValues<int32_t>()) {
         if (correspondingDim != perm0.getValues<int32_t>()[val]) {
-          return failure();
+          userIsInverseTranspose = false;
+          break;
         }
         correspondingDim += 1;
       }
+
+      if (userIsInverseTranspose) {
+        // Can bypass this transpose -> inverse transpose pair
+        rewriter.replaceAllUsesWith(userTransposeOp.getResult(), transposeOp.getInput());
+        // And erase the inverse transpose ops
+        rewriter.eraseOp(userTransposeOp);
+        IRModified = true;
+      }
     }
 
-    // Reaching this stage means all user ops are exact inverse transpose ops
-    // Removing all of them
-    for (Operation *userOp : users) {
-      auto userTransposeOp = dyn_cast<TFL::TransposeOp>(userOp);
-      rewriter.replaceAllUsesWith(userTransposeOp.getResult(), transposeOp.getInput());
-      rewriter.eraseOp(userOp);
+    if (allUserErased) {
+      // All user ops are the equivant inverse transpose ops
+      // Remove the transpose ops
+      rewriter.eraseOp(transposeOp);
+      IRModified = true;
     }
-    rewriter.eraseOp(transposeOp);
-    return success();
+    if (IRModified) {
+      return success();
+    }
+    return failure();    
   }
 };
 
@@ -765,9 +782,11 @@ void OptimizeTranspose::runOnOperation() {
 
   (void)applyPatternsAndFoldGreedily(func, std::move(patterns));
 
-  // Erase double transpose optimizations
+  // Erase double transpose optimizations and merge if there is leftover
   RewritePatternSet erasePatterns(ctx);
   erasePatterns.insert<EraseDoubleTransposePattern>(ctx);
+  erasePatterns.insert<FoldDoubleTransposePattern>(ctx);
+  erasePatterns.insert<FoldTransposeToReshapePattern>(ctx);
 
   (void)applyPatternsAndFoldGreedily(func, std::move(erasePatterns));
 }

--- a/xformer/Transforms/OptimizeTranspose.cpp
+++ b/xformer/Transforms/OptimizeTranspose.cpp
@@ -228,6 +228,8 @@ struct EraseDoubleTransposePattern : public OpRewritePattern<TFL::TransposeOp> {
         // And erase the inverse transpose ops
         rewriter.eraseOp(userTransposeOp);
         IRModified = true;
+      } else {
+        allUserErased = false;
       }
     }
 


### PR DESCRIPTION
Added an erase pattern such that redundant transpose ops will be eliminate from the graph

For example
<img width="320" alt="image" src="https://github.com/user-attachments/assets/ade4c61e-cfb3-4ee2-b7df-4e6b685b8d9e" />
The three transpose ops will be eliminated, as they are doing nothing.
This PR will make the final graph like this
<img width="320" alt="image" src="https://github.com/user-attachments/assets/a329a870-8019-433f-a7f7-5c5e48d4df41" />
